### PR TITLE
Adds uid property to alarms

### DIFF
--- a/lib/icalendar/component/alarm.rb
+++ b/lib/icalendar/component/alarm.rb
@@ -17,6 +17,7 @@ module Icalendar
     ical_property :description
     ical_property :trigger
     ical_property :summary
+    ical_property :uid
     
     # Single but must appear together
     ical_property :duration


### PR DESCRIPTION
This fixes https://github.com/sdague/icalendar/issues/6

There are no related tests to alarms. However I have manually tested it and found it working.

This makes sure iCloud calendars (which use uid for alarms) can be parsed.

Do you also want to release a new version with this fix? Thx. :)
