### PR TITLE
Weekdays in RRule output corrected

### DIFF
--- a/lib/icalendar/rrule.rb
+++ b/lib/icalendar/rrule.rb
@@ -68,9 +68,9 @@ module Icalendar
       @by_list.each do |key, value|
         if value
           if key == :byday
-            result << ";BYDAY=#{value.join(',')}"
+            result << ";BYDAY=#{value.join ','}"
           else
-            result << ";#{key.to_s.upcase}=#{value}" if value
+            result << ";#{key.to_s.upcase}=#{value}"
           end
         end
       end


### PR DESCRIPTION
The RRule class used to display the weekdays in a BYDAY clause surrounded by [], eg. [MO] instead of just MO, or [TU,WE] instead of TU,WE. This is not correct according to RFC 5545, so I changed it. Weekdays are now joined with `join ','`, so I also removed `@last` and `you_are_last()`.
