### PR TITLE
Semicolon for GEO property should not be escaped

### DIFF
--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -144,7 +144,7 @@ module Icalendar
 
           # Property value
           value = ":#{val.to_ical}"
-          value = escape_chars(value) unless %w[rrule categories exdate].include?(key)
+          value = escape_chars(value) unless %w[geo rrule categories exdate].include?(key)
           add_sliced_text(s, prelude + value)
         else
           prelude = "#{key.gsub(/_/, '-').upcase}"


### PR DESCRIPTION
Semicolon divider of a GEO property is getting escaped in to_ical call. It seems to be a mistake, so here is a fix
