### PR TITLE
Update Component#respond_to? to match ruby 2.0 signature

### DIFF
--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -429,9 +429,9 @@ module Icalendar
 
     public
 
-    def respond_to?(method_name)
+    def respond_to?(method_name, include_all=false)
       if method_name.to_s.downcase =~ /x_.*/
-       true
+        true
       else
         super
       end


### PR DESCRIPTION
Since it is only the additional optional attribute, it should have no impact aside from silencing warnings in rspec-mocks and ruby 2.0.
