### PR TITLE
Nilcheck e.dtend to allow events with no end time

### DIFF
--- a/lib/icalendar/calendar.rb
+++ b/lib/icalendar/calendar.rb
@@ -50,7 +50,7 @@ module Icalendar
         e.instance_eval(&block)
         if e.tzid
           e.dtstart.ical_params = { "TZID" => e.tzid }
-          e.dtend.ical_params = { "TZID" => e.tzid }
+          e.dtend.ical_params = { "TZID" => e.tzid } if e.dtend
         end
       end
 


### PR DESCRIPTION
As I understand the ics standard, it is allowed to have an event without an end time. However, if you use timezones, this breaks the app due to calling `ical_params` on `nil`. This pull-request includes a simple nil-check on `e.dtend` before doing that.
