### PR TITLE
Fix: undefined local variable or method `e'

### DIFF
--- a/lib/icalendar/calendar.rb
+++ b/lib/icalendar/calendar.rb
@@ -42,8 +42,8 @@ module Icalendar
         if block
           instance_eval(&block)
           if tzid
-            dtstart.ical_params = { "TZID" => e.tzid }
-            dtend.ical_params = { "TZID" => e.tzid } unless dtend.nil?
+            dtstart.ical_params = { "TZID" => tzid }
+            dtend.ical_params = { "TZID" => tzid } unless dtend.nil?
           end
         end
       end

--- a/test/test_calendar.rb
+++ b/test/test_calendar.rb
@@ -43,6 +43,26 @@ class TestCalendar < Test::Unit::TestCase
       end
    end
 
+   def test_block_creation_with_timezone
+      cal = Calendar.new
+
+      event_start = DateTime.new 1997, 9, 3, 19, 0, 0
+      tz = TZInfo::Timezone.get "Europe/Copenhagen"
+      timezone = tz.ical_timezone event_start
+      cal.add timezone
+
+      cal.event do
+         dtstart event_start
+         dtend "19970903T190000Z"
+         summary "This is my summary"
+      end
+
+      cal.events.each do |ev|
+         assert_equal(event_start, ev.dtstart)
+         assert_equal("19970903T190000Z", ev.dtend)
+      end
+   end
+
    def test_create_multiple_event_calendar
        # Create a fresh calendar
        Timecop.freeze DateTime.new(2013, 12, 26, 5, 0, 0, '+0000')


### PR DESCRIPTION
The example of using timezones from the README (https://github.com/icalendar/icalendar#example) was causing the following error :

```
NameError:
  undefined local variable or method `e' for #<Icalendar::Event:0x007fc94f7a35f8>
```

This appears to be a leftover from 6a5bd05c - where the Event was previously passed around as `e`, it should now use implicit `self`.

This commit makes the code use the implicit self, and adds a test case which catches this error, based upon the code in the README.

I was unsure if there was an existing convention for test cases like this, so for the moment I have just placed it near a similar block event case. Happy to move if it should go elsewhere.
