### PR TITLE
Out-of-spec `related_to` for alarm, re #41

### DIFF
--- a/lib/icalendar/alarm.rb
+++ b/lib/icalendar/alarm.rb
@@ -19,6 +19,7 @@ module Icalendar
     # not part of base spec - need better abstraction for extensions
     optional_single_property :uid
     optional_single_property :acknowledged, Icalendar::Values::DateTime
+    optional_single_property :related_to
 
     def initialize
       super 'alarm'

--- a/lib/icalendar/version.rb
+++ b/lib/icalendar/version.rb
@@ -1,5 +1,5 @@
 module Icalendar
 
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 
 end


### PR DESCRIPTION
Looks like a regression in the changes between 0b0eb67 and 48c0d02

Also, version bump
