### PR TITLE
Implement Icalendar::Values::Text#to_ary

### DIFF
--- a/lib/icalendar/values/text.rb
+++ b/lib/icalendar/values/text.rb
@@ -20,6 +20,10 @@ module Icalendar
         end
       end
 
+      def to_ary
+        [ self ]
+      end
+
     end
 
   end


### PR DESCRIPTION
In order to avoid the delegation to String#to_a which is called by
Kernel.Array, this implements Icalendar::Values::Text#to_ary.

(Fix #74)
