### PR TITLE
Use SecureRandom.uuid in Component#new_uid

### DIFF
--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -1,4 +1,4 @@
-require 'socket'
+require 'securerandom'
 
 module Icalendar
 
@@ -17,7 +17,7 @@ module Icalendar
     end
 
     def new_uid
-      "#{DateTime.now}_#{rand(999999999)}@#{Socket.gethostname}"
+      SecureRandom.uuid
     end
 
     def to_ical


### PR DESCRIPTION
It may be controversial but I would prefer to not expose the hostname and to use the standard Ruby way of generating UUID. Others iCalendar libraries don't use the proposed RFC way (see [http://tools.ietf.org/html/rfc5545#section-3.8.4.7](http://tools.ietf.org/html/rfc5545#section-3.8.4.7)), so I don't think this is a big deal.
