### PR TITLE
Eliminate warnings

### DIFF
--- a/lib/icalendar/values/text.rb
+++ b/lib/icalendar/values/text.rb
@@ -1,8 +1,6 @@
 module Icalendar
   module Values
-
     class Text < Value
-
       def initialize(value, params = {})
         value = value.gsub '\n', "\n"
         value.gsub! '\,', ','
@@ -16,11 +14,9 @@ module Icalendar
           v.gsub!('\\') { '\\\\' }
           v.gsub! ';', '\;'
           v.gsub! ',', '\,'
-          v.gsub! /\r?\n/, '\n'
+          v.gsub!(/\r?\n/, '\n')
         end
       end
-
     end
-
   end
 end

--- a/lib/icalendar/values/utc_offset.rb
+++ b/lib/icalendar/values/utc_offset.rb
@@ -2,9 +2,7 @@ require 'ostruct'
 
 module Icalendar
   module Values
-
     class UtcOffset < Value
-
       def initialize(value, params = {})
         if value.is_a? Icalendar::Values::UtcOffset
           value = value.value
@@ -30,7 +28,7 @@ module Icalendar
       end
 
       def parse_fields(value)
-        value.gsub! /\s+/, ''
+        value.gsub!(/\s+/, '')
         md = /\A(?<behind>[+-])(?<hours>\d{2})(?<minutes>\d{2})(?<seconds>\d{2})?\z/.match value
         {
           behind: (md[:behind] == '-'),


### PR DESCRIPTION
I saw warnings.

/Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/icalendar-2.1.1/lib/icalendar/values/text.rb:19: warning: ambiguous first argument; put parentheses or even spaces
/Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/icalendar-2.1.1/lib/icalendar/values/utc_offset.rb:33: warning: ambiguous first argument; put parentheses or even spaces

---

My environment.
MacOSX 10.9.4
ruby --version
ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]
