### PR TITLE
Tolerate malformed lines when parsing non-strict

### DIFF
--- a/spec/fixtures/single_event_bad_line.ics
+++ b/spec/fixtures/single_event_bad_line.ics
@@ -1,0 +1,22 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:bsprodidfortestabc123
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTAMP:20050118T211523Z
+UID:bsuidfortestabc123
+DTSTART;TZID=US-Mountain:20050120T170000
+DTEND;TZID=US-Mountain:20050120T184500
+CLASS:PRIVATE
+GEO:37.386013;-122.0829322
+ORGANIZER:mailto:joebob@random.net
+PRIORITY:2
+SUMMARY:This is a really long summary to test the method of unfolding lines
+ \, so I'm just going to make it a whole bunch of lines.
+ATTACH:http://bush.sucks.org/impeach/him.rhtml
+ATTACH:http://corporations-dominate.existence.net/why.rhtml
+RDATE;TZID=US-Mountain:20050121T170000,20050122T170000
+X-TEST-COMPONENT;QTEST="Hello, World":Shouldn't double double quotes
+X-NO-VALUE
+END:VEVENT
+END:VCALENDAR

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe Icalendar::Parser do
-
-  let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'single_event.ics') }
   subject { described_class.new source, false }
 
   describe '#parse' do
+    let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'single_event.ics') }
+
     it 'returns an array of calendars' do
       expect(subject.parse).to be_instance_of Array
       expect(subject.parse.count).to eq 1
@@ -23,4 +23,23 @@ describe Icalendar::Parser do
     end
   end
 
+  describe '#parse with bad line' do
+    let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'single_event_bad_line.ics') }
+
+    it 'returns an array of calendars' do
+      expect(subject.parse).to be_instance_of Array
+      expect(subject.parse.count).to eq 1
+      expect(subject.parse[0]).to be_instance_of Icalendar::Calendar
+    end
+
+    it 'properly splits multi-valued lines' do
+      event = subject.parse.first.events.first
+      expect(event.geo).to eq [37.386013,-122.0829322]
+    end
+
+    it 'saves params' do
+      event = subject.parse.first.events.first
+      expect(event.dtstart.ical_params).to eq('tzid' => ['US-Mountain'])
+    end
+  end
 end


### PR DESCRIPTION
Relaxes the strictness of non-strict mode so that badly formed lines are tolerated enough for the parser to proceed.

Fixes #75
