### PR TITLE
Use more specific check for ActiveSupport timezone support

### DIFF
--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -12,7 +12,7 @@ module Icalendar
       def initialize(value, params = {})
         @tz_utc = params['tzid'] == 'UTC'
 
-        if defined?(ActiveSupport) && !params['tzid'].nil?
+        if defined?(ActiveSupport::TimeZone) && defined?(ActiveSupport::TimeWithZone) && !params['tzid'].nil?
           tzid = params['tzid'].is_a?(::Array) ? params['tzid'].first : params['tzid']
           zone = ActiveSupport::TimeZone[tzid]
           value = ActiveSupport::TimeWithZone.new nil, zone, value unless zone.nil?


### PR DESCRIPTION
Just checking for ActiveSupport isn't enough.  Some libraries
define the top level ActiveSupport module, that doesn't mean
that the classes you need to use exist.

See https://github.com/mikel/mail/pull/816 for an example,
where loading icalendar and mail without activesupport being
installed results in a broken icalendar.
