### PR TITLE
Adapt ActiveSupport::TimeWithZone#to_a to fix multi_property

### DIFF
--- a/lib/icalendar/values/active_support_time_with_zone_adapter.rb
+++ b/lib/icalendar/values/active_support_time_with_zone_adapter.rb
@@ -1,0 +1,12 @@
+module Icalendar
+  module Values
+    class ActiveSupportTimeWithZoneAdapter < ActiveSupport::TimeWithZone
+      # ActiveSupport::TimeWithZone implements a #to_a method that will cause
+      # unexpected behavior in components with multi_property DateTime
+      # properties when the setters for those properties are invoked with an
+      # Icalendar::Values::DateTime that is delegating for an
+      # ActiveSupport::TimeWithZone. To avoid this behavior, undefine #to_a.
+      undef_method :to_a
+    end
+  end
+end

--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -1,5 +1,9 @@
 begin
   require 'active_support/time'
+
+  if defined?(ActiveSupport::TimeWithZone)
+    require 'icalendar/values/active_support_time_with_zone_adapter'
+  end
 rescue LoadError
   # tis ok, just a bit less fancy
 end
@@ -12,10 +16,10 @@ module Icalendar
       def initialize(value, params = {})
         @tz_utc = params['tzid'] == 'UTC'
 
-        if defined?(ActiveSupport::TimeZone) && defined?(ActiveSupport::TimeWithZone) && !params['tzid'].nil?
+        if defined?(ActiveSupport::TimeZone) && defined?(ActiveSupportTimeWithZoneAdapter) && !params['tzid'].nil?
           tzid = params['tzid'].is_a?(::Array) ? params['tzid'].first : params['tzid']
           zone = ActiveSupport::TimeZone[tzid]
-          value = ActiveSupport::TimeWithZone.new nil, zone, value unless zone.nil?
+          value = ActiveSupportTimeWithZoneAdapter.new nil, zone, value unless zone.nil?
           super value, params
         else
           super

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -82,6 +82,18 @@ describe Icalendar::Event do
         expect(subject.comment).to eq ['a comment']
       end
     end
+
+    if defined? ActiveSupport
+      describe '#rdate' do
+        it 'does not convert a DateTime delegating for an ActiveSupport::TimeWithZone into an Array' do
+          timestamp = '20140130T230000Z'
+          expected = [Icalendar::Values::DateTime.new(timestamp)]
+
+          subject.rdate = timestamp
+          expect(subject.rdate).to eq(expected)
+        end
+      end
+    end
   end
 
   describe '#find_alarm' do


### PR DESCRIPTION
Ran into an issue today where a `Icalendar::Values::DateTime` that was delegating for an `ActiveSupport::TimeWithZone` was doing strange things when given as the argument to `Event#rdate=`.

The problem stemmed from the fact that `ActiveSupport::TimeWithZone` implements a `to_a` method that was implicitly being called from the `rdate=` `multi_property` setter by `Kernel#Array`. This was causing the `to_ical` method on an `Event` to die because it was trying to call `to_ical` on all of the elements of the Array returned by `ActiveSupport::TimeWithZone#to_a` which looks like this:

``` ruby
DateTime.parse('20140130T230000Z').in_time_zone('UTC').to_a
# => [0, 0, 23, 30, 1, 2014, 4, 30, false, 'UTC']
```

This approach feels kind of hackish, but given the delegation that's going on, I couldn't come up with a better idea to fix the problem. Given that this solution is kind of unintuitive, I tried to add a big comment to explain what was going on. If you have a better idea, let me know and I can look into implementing it.
