### PR TITLE
More descriptive error for unparseable Date

### DIFF
--- a/lib/icalendar/values/date.rb
+++ b/lib/icalendar/values/date.rb
@@ -8,7 +8,13 @@ module Icalendar
 
       def initialize(value, params = {})
         if value.is_a? String
-          super ::Date.strptime(value, FORMAT), params
+          begin
+            parsed_date = ::Date.strptime(value, FORMAT)
+          rescue ArgumentError => e
+            raise FormatError.new("Failed to parse \"#{value}\" - #{e.message}")
+          end
+
+          super parsed_date, params
         elsif value.respond_to? :to_date
           super value.to_date, params
         else
@@ -28,6 +34,8 @@ module Icalendar
         end
       end
 
+      class FormatError < ArgumentError
+      end
     end
 
   end

--- a/spec/values/date_or_date_time_spec.rb
+++ b/spec/values/date_or_date_time_spec.rb
@@ -29,5 +29,13 @@ describe Icalendar::Values::DateOrDateTime do
         expect(subject.call.value).to eq Date.new(2014, 2, 9)
       end
     end
+
+    context 'unparseable date' do
+      let(:value) { '99999999' }
+
+      it 'raises an error including the unparseable time' do
+        expect { subject.call }.to raise_error(ArgumentError, %r{Failed to parse \"#{value}\"})
+      end
+    end
   end
 end


### PR DESCRIPTION
Similar to 8e37bcb (#99), raises an error which also include the unparseable value to aid debugging.