### PR TITLE
add support for X-WR-CALNAME and X-WR-CALDESC properties

### DIFF
--- a/lib/icalendar/calendar.rb
+++ b/lib/icalendar/calendar.rb
@@ -5,6 +5,9 @@ module Icalendar
     required_property :prodid
     optional_single_property :calscale
     optional_single_property :ip_method
+    optional_single_property :x_wr_calname
+    optional_single_property :x_published_ttl
+    optional_single_property :x_wr_caldesc
 
     component :timezone, :tzid
     component :event
@@ -17,6 +20,9 @@ module Icalendar
       self.prodid = 'icalendar-ruby'
       self.version = '2.0'
       self.calscale = 'GREGORIAN'
+      self.x_wr_calname = nil
+      self.x_published_ttl = nil
+      self.x_wr_caldesc = nil
     end
 
     def publish

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -117,6 +117,9 @@ describe Icalendar::Calendar do
   describe '#to_ical' do
     before(:each) do
       Timecop.freeze DateTime.new(2013, 12, 26, 5, 0, 0, '+0000')
+      subject.x_wr_calname = "My calendar name"
+      subject.x_wr_caldesc = "A description"
+
       subject.event do |e|
         e.summary = 'An event'
         e.dtstart = "20140101T000000Z"
@@ -139,6 +142,8 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:icalendar-ruby
 CALSCALE:GREGORIAN
+X-WR-CALNAME:My calendar name
+X-WR-CALDESC:A description
 BEGIN:VEVENT
 DTSTAMP:20131226T050000Z
 DTSTART:20140101T000000Z


### PR DESCRIPTION
I use icalendar to generate a calendar url that people can subscribe to.

When subscribing to a calendar via "google calendar", you can only fill the url of the calendar you want to subscribe to. The name of the calendar is taken from a non standard property: X-WR-CALNAME.
If this property doesn't exist, it will show the full calendar url instead.

I added three optional properties X-WR-CALNAME. X-PUBLISHED-TTL and X-WR-CALDESC and now it works great.

