### PR TITLE
Allows the Parser to handle event files as well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 before_install:
   - gem install bundler
 language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - 2.3
+  - 2.3.0
   - 2.2
   - 2.1
   - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+before_install:
+  - gem install bundler
 language: ruby
 rvm:
+  - 2.3
+  - 2.2
   - 2.1
   - 2.0
   - 1.9.3

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Parsing iCalendars
 
     # Parser returns an array of calendars because a single file
     # can have multiple calendars.
-    cals = Icalendar.parse(cal_file)
+    cals = Icalendar::Calendar.parse(cal_file)
     cal = cals.first
 
     # Now you can access the cal object in just the same way I created it
@@ -273,14 +273,14 @@ strict parsing:
     strict_parser = Icalendar::Parser.new(cal_file, true)
     cal = strict_parser.parse
 
-Parsing Events
+Parsing Components (e.g. Events)
 ---
     # Open a file or pass a string to the parser
     event_file = File.open("event.ics")
 
-    # Parser returns an array of calendars because a single file
+    # Parser returns an array of events because a single file
     # can have multiple calendars.
-    events = Icalendar.parse(event_file)
+    events = Icalendar::Event.parse(event_file)
     event = events.first
 
     puts "start date-time: #{event.dtstart}"

--- a/README.md
+++ b/README.md
@@ -273,6 +273,20 @@ strict parsing:
     strict_parser = Icalendar::Parser.new(cal_file, true)
     cal = strict_parser.parse
 
+Parsing Events
+---
+    # Open a file or pass a string to the parser
+    event_file = File.open("event.ics")
+
+    # Parser returns an array of calendars because a single file
+    # can have multiple calendars.
+    events = Icalendar.parse(event_file)
+    event = events.first
+
+    puts "start date-time: #{event.dtstart}"
+    puts "start date-time timezone: #{event.dtstart.ical_params['tzid']}"
+    puts "summary: #{event.summary}"
+
 Finders
 ---
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Parsing Components (e.g. Events)
     event_file = File.open("event.ics")
 
     # Parser returns an array of events because a single file
-    # can have multiple calendars.
+    # can have multiple events.
     events = Icalendar::Event.parse(event_file)
     event = events.first
 

--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -13,6 +13,7 @@ module Icalendar
   end
 
   def self.parse(source, single = false)
+    logger.info("DEPRECATION WARNING: Icalender.parse will be removed in the future.\nPlease use Icalendar::Calendar.parse.")
     calendars = Parser.new(source).parse
     single ? calendars.first : calendars
   end

--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -13,8 +13,8 @@ module Icalendar
   end
 
   def self.parse(source, single = false)
-    calendars = Parser.new(source).parse
-    single ? calendars.first : calendars
+    calendars_or_events = Parser.new(source).parse
+    single ? calendars_or_events.first : calendars_or_events
   end
 
 end

--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -13,7 +13,7 @@ module Icalendar
   end
 
   def self.parse(source, single = false)
-    puts "**** DEPRECATION WARNING ****\nIcalender.parse will be removed. Please switch to Icalendar::Calendar.parse."
+    warn "**** DEPRECATION WARNING ****\nIcalender.parse will be removed. Please switch to Icalendar::Calendar.parse."
     calendars = Parser.new(source).parse
     single ? calendars.first : calendars
   end

--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -13,8 +13,8 @@ module Icalendar
   end
 
   def self.parse(source, single = false)
-    calendars_or_events = Parser.new(source).parse
-    single ? calendars_or_events.first : calendars_or_events
+    calendars = Parser.new(source).parse
+    single ? calendars.first : calendars
   end
 
 end

--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -13,7 +13,7 @@ module Icalendar
   end
 
   def self.parse(source, single = false)
-    logger.info("DEPRECATION WARNING: Icalender.parse will be removed in the future.\nPlease use Icalendar::Calendar.parse.")
+    puts "**** DEPRECATION WARNING ****\nIcalender.parse will be removed. Please switch to Icalendar::Calendar.parse."
     calendars = Parser.new(source).parse
     single ? calendars.first : calendars
   end

--- a/lib/icalendar/calendar.rb
+++ b/lib/icalendar/calendar.rb
@@ -23,10 +23,6 @@ module Icalendar
       self.ip_method = 'PUBLISH'
     end
 
-    def parseable?
-      true
-    end
-
   end
 
 end

--- a/lib/icalendar/calendar.rb
+++ b/lib/icalendar/calendar.rb
@@ -22,6 +22,11 @@ module Icalendar
     def publish
       self.ip_method = 'PUBLISH'
     end
+
+    def parseable?
+      true
+    end
+
   end
 
 end

--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -3,8 +3,6 @@ require 'securerandom'
 module Icalendar
 
   class Component
-    class NotParseableError < StandardError; end
-
     include HasProperties
     include HasComponents
 
@@ -35,10 +33,6 @@ module Icalendar
         ical_components,
         "END:#{ical_name}\r\n"
       ].compact.join "\r\n"
-    end
-
-    def parseable?
-      false
     end
 
     private

--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -3,6 +3,8 @@ require 'securerandom'
 module Icalendar
 
   class Component
+    class NotParseableError < StandardError; end
+
     include HasProperties
     include HasComponents
 
@@ -12,7 +14,7 @@ module Icalendar
 
     def self.parse(source)
       parser = Parser.new(source)
-      parser.component = self.to_s
+      parser.component = self.new
       parser.parse
     end
 
@@ -33,6 +35,10 @@ module Icalendar
         ical_components,
         "END:#{ical_name}\r\n"
       ].compact.join "\r\n"
+    end
+
+    def parseable?
+      false
     end
 
     private

--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -10,6 +10,12 @@ module Icalendar
     attr_reader :ical_name
     attr_accessor :parent
 
+    def self.parse(source)
+      parser = Parser.new(source)
+      parser.component = self.to_s
+      parser.parse
+    end
+
     def initialize(name, ical_name = nil)
       @name = name
       @ical_name = ical_name || "V#{name.upcase}"

--- a/lib/icalendar/event.rb
+++ b/lib/icalendar/event.rb
@@ -46,6 +46,10 @@ module Icalendar
       self.uid = new_uid
     end
 
+    def parseable?
+      true
+    end
+
   end
 
 end

--- a/lib/icalendar/event.rb
+++ b/lib/icalendar/event.rb
@@ -46,10 +46,6 @@ module Icalendar
       self.uid = new_uid
     end
 
-    def parseable?
-      true
-    end
-
   end
 
 end

--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -21,13 +21,15 @@ module Icalendar
     def parse
       source.rewind
       read_in_data
-      calendars = []
+      calendars_or_events = []
       while (fields = next_fields)
         if fields[:name] == 'begin' && fields[:value].downcase == 'vcalendar'
-          calendars << parse_component(Calendar.new)
+          calendars_or_events << parse_component(Calendar.new)
+        elsif fields[:name] == 'begin' && fields[:value].downcase == 'vevent'
+          calendars_or_events << parse_component(Event.new)
         end
       end
-      calendars
+      calendars_or_events
     end
 
     def parse_property(component, fields = nil)

--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -19,8 +19,6 @@ module Icalendar
     end
 
     def parse
-      raise ::Icalendar::Component::NotParseableError, "Parsing of #{self} not supported." unless component.parseable?
-
       source.rewind
       read_in_data
       components = []

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -96,6 +96,18 @@ describe Icalendar::Event do
     end
   end
 
+  describe '.parse' do
+    let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', fn) }
+    let(:fn) { 'event.ics' }
+
+    it 'should return an events array' do
+      events = Icalendar::Event.parse(source)
+      expect(events).to be_instance_of Array
+      expect(events.count).to be 1
+      expect(events.first).to be_instance_of Icalendar::Event
+    end
+  end
+
   describe '#find_alarm' do
     it 'should not respond_to find_alarm' do
       expect(subject.respond_to?(:find_alarm)).to be false

--- a/spec/fixtures/event.ics
+++ b/spec/fixtures/event.ics
@@ -1,0 +1,17 @@
+BEGIN:VEVENT
+DTSTAMP:20050118T211523Z
+UID:bsuidfortestabc123
+DTSTART;TZID=US-Mountain:20050120T170000
+DTEND;TZID=US-Mountain:20050120T184500
+CLASS:PRIVATE
+GEO:37.386013;-122.0829322
+ORGANIZER:mailto:joebob@random.net
+PRIORITY:2
+SUMMARY:This is a really long summary to test the method of unfolding lines
+ \, so I'm just going to make it a whole bunch of lines.
+ATTACH:http://bush.sucks.org/impeach/him.rhtml
+ATTACH:http://corporations-dominate.existence.net/why.rhtml
+RDATE;TZID=US-Mountain:20050121T170000,20050122T170000
+X-TEST-COMPONENT;QTEST="Hello, World":Shouldn't double double quotes
+END:VEVENT
+

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -35,7 +35,7 @@ describe Icalendar::Parser do
     context 'event.ics' do
       let(:fn) { 'event.ics' }
 
-      before { subject.component = "Icalendar::Event" }
+      before { subject.component = Icalendar::Event.new }
 
       it 'returns an array of events' do
         expect(subject.parse).to be_instance_of Array
@@ -47,12 +47,12 @@ describe Icalendar::Parser do
     context 'not yet supported component' do
       let(:fn) { 'event.ics' }
 
-      before { subject.component = "Icalendar::Alarm" }
+      before { subject.component = Icalendar::Alarm.new }
 
       it 'returns an array of events' do
         expect {
           subject.parse
-        }.to raise_error(Icalendar::ComponentNotParseableError)
+        }.to raise_error(Icalendar::Component::NotParseableError)
       end
     end
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -32,6 +32,14 @@ describe Icalendar::Parser do
         expect(ics).to match 'EXDATE;VALUE=DATE:20120323,20130323'
       end
     end
+    context 'event.ics' do
+      let(:fn) { 'event.ics' }
+      it 'returns an array of events' do
+        expect(subject.parse).to be_instance_of Array
+        expect(subject.parse.count).to be 1
+        expect(subject.parse[0]).to be_instance_of Icalendar::Event
+      end
+    end
   end
 
   describe '#parse with bad line' do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -34,10 +34,25 @@ describe Icalendar::Parser do
     end
     context 'event.ics' do
       let(:fn) { 'event.ics' }
+
+      before { subject.component = "Icalendar::Event" }
+
       it 'returns an array of events' do
         expect(subject.parse).to be_instance_of Array
         expect(subject.parse.count).to be 1
         expect(subject.parse[0]).to be_instance_of Icalendar::Event
+      end
+    end
+
+    context 'not yet supported component' do
+      let(:fn) { 'event.ics' }
+
+      before { subject.component = "Icalendar::Alarm" }
+
+      it 'returns an array of events' do
+        expect {
+          subject.parse
+        }.to raise_error(Icalendar::ComponentNotParseableError)
       end
     end
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -43,18 +43,6 @@ describe Icalendar::Parser do
         expect(subject.parse[0]).to be_instance_of Icalendar::Event
       end
     end
-
-    context 'not yet supported component' do
-      let(:fn) { 'event.ics' }
-
-      before { subject.component = Icalendar::Alarm.new }
-
-      it 'returns an array of events' do
-        expect {
-          subject.parse
-        }.to raise_error(Icalendar::Component::NotParseableError)
-      end
-    end
   end
 
   describe '#parse with bad line' do

--- a/spec/roundtrip_spec.rb
+++ b/spec/roundtrip_spec.rb
@@ -6,12 +6,13 @@ describe Icalendar do
     let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'single_event.ics') }
 
     it 'will generate the same file as is parsed' do
-      expect(Icalendar.parse(source, true).to_ical).to eq source
+      ical = Icalendar::Calendar.parse(source).first.to_ical
+      expect(ical).to eq source
     end
 
     it 'array properties can be assigned to a new event' do
       event = Icalendar::Event.new
-      parsed = Icalendar.parse source, true
+      parsed = Icalendar::Calendar.parse(source).first
       event.rdate = parsed.events.first.rdate
       expect(event.rdate.first).to be_kind_of Icalendar::Values::Array
       expect(event.rdate.first.ical_params).to eq 'tzid' => ['US-Mountain']
@@ -21,13 +22,14 @@ describe Icalendar do
   describe 'timezone round trip' do
     let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'timezone.ics') }
     it 'will generate the same file as it parsed' do
-      expect(Icalendar.parse(source, true).to_ical).to eq source
+      ical = Icalendar::Calendar.parse(source).first.to_ical
+      expect(ical).to eq source
     end
   end
 
   describe 'non-default values' do
     let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'nondefault_values.ics') }
-    subject { Icalendar.parse(source, true).events.first }
+    subject { Icalendar::Calendar.parse(source).first.events.first }
 
     it 'will set dtstart to Date' do
       expect(subject.dtstart.value).to eq ::Date.new(2006, 12, 15)
@@ -48,7 +50,7 @@ describe Icalendar do
 
   describe 'sorting daily events' do
     let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'two_day_events.ics') }
-    subject { Icalendar.parse(source, true).events }
+    subject { Icalendar::Calendar.parse(source).first.events }
 
     it 'sorts day events' do
       events = subject.sort_by(&:dtstart)
@@ -60,7 +62,7 @@ describe Icalendar do
 
   describe 'sorting time events' do
     let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'two_time_events.ics') }
-    subject { Icalendar.parse(source, true).events }
+    subject { Icalendar::Calendar.parse(source).first.events }
 
     it 'sorts time events by start time' do
       events = subject.sort_by(&:dtstart)
@@ -82,7 +84,7 @@ describe Icalendar do
 
   describe 'sorting date / time events' do
     let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', 'two_date_time_events.ics') }
-    subject { Icalendar.parse(source, true).events }
+    subject { Icalendar::Calendar.parse(source).first.events }
 
     it 'sorts time events' do
       events = subject.sort_by(&:dtstart)


### PR DESCRIPTION
!WIP! 

* I don't like the `calendars_or_events` variable.
* I don't like the fact that the very same file may contain multiple calendars and events.

I like the fact, that the interface stays the same. E.g. `Icalendar.parse` works for both events and calendars. However it should be clear, that you can parse either calendar or event files. 

Regarding the `Icalendar::Parser`:

What do you think about a guard in the parser which makes sure that events and calendars can't be mixed?

What do you think about extending the interface to sth. like:

`Icalendar::Parser.new(:calendar, source)`

or 

`Icalendar::Parser.new(:event, source)`

STI would be an option as well `Icalendar::EventParser.new(source)` or `Icalendar::CalendarParser.new(source)` where both parsers inherit from `Icalendar::Parser.new` and override/extend the parse method.

This way it would be a lot clearer what we expect from the source and what it will return... We would get rid of the `calendars_or_events` variable and it would be nicely decoupled?

Please tell me what you think :)



