### PR TITLE
Added support for icloud alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ ALARMS
         a.trigger       = "-PT15M"
         a.append_attach "Basso"
       end
+
+      e.alarm do |a|
+        a.summary = "Alarm notification, icloud style"
+        a.trigger = "-PT15M" # 15 minutes before
+        a.x_wr_alarmuid = UUID.new.generate
+      end
     end
 
 #### Output ####

--- a/lib/icalendar/alarm.rb
+++ b/lib/icalendar/alarm.rb
@@ -19,6 +19,7 @@ module Icalendar
     # not part of base spec - need better abstraction for extensions
     optional_single_property :uid
     optional_single_property :acknowledged, Icalendar::Values::DateTime
+    optional_single_property :x_wr_alarmuid # uid for icloud alarms
 
     def initialize
       super 'alarm'

--- a/spec/alarm_spec.rb
+++ b/spec/alarm_spec.rb
@@ -36,6 +36,11 @@ describe Icalendar::Alarm do
         subject.description = 'Display Text'
         expect(subject).to be_valid
       end
+      it 'accepts x_wr_alarmuid' do
+        subject.description = 'Display Text'
+        subject.x_wr_alarmuid = 'fea170d0-1e52-0134-1e24-486000b2404b'
+        expect(subject).to be_valid
+      end
     end
 
     context 'email action' do


### PR DESCRIPTION
A small change to allow icalendar to accept the alarm uuid parameter x_wr_alarmuid, required by icloud's api