### PR TITLE
create a new component instance for each component

### DIFF
--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -12,7 +12,7 @@ module Icalendar
 
     def self.parse(source)
       parser = Parser.new(source)
-      parser.component = self.new
+      parser.component_class = self
       parser.parse
     end
 

--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -1,7 +1,7 @@
 module Icalendar
 
   class Parser
-    attr_writer :component
+    attr_writer :component_class
     attr_reader :source, :strict
 
     def initialize(source, strict = false)
@@ -23,6 +23,7 @@ module Icalendar
       read_in_data
       components = []
       while (fields = next_fields)
+        component = component_class.new
         if fields[:name] == 'begin' && fields[:value].downcase == component.ical_name.downcase
           components << parse_component(component)
         end
@@ -93,8 +94,8 @@ module Icalendar
 
     private
 
-    def component
-      @component ||= Icalendar::Calendar.new
+    def component_class
+      @component_class ||= Icalendar::Calendar
     end
 
     def parse_component(component)

--- a/spec/fixtures/two_events.ics
+++ b/spec/fixtures/two_events.ics
@@ -1,0 +1,28 @@
+BEGIN:VEVENT
+DTSTAMP:20050118T211523Z
+UID:bsuidfortestabc123
+DTSTART;TZID=US-Mountain:20050120T170000
+DTEND;TZID=US-Mountain:20050120T184500
+CLASS:PRIVATE
+GEO:37.386013;-122.0829322
+ORGANIZER:mailto:joebob@random.net
+PRIORITY:2
+SUMMARY:This is a really long summary to test the method of unfolding lines
+ \, so I'm just going to make it a whole bunch of lines.
+ATTACH:http://bush.sucks.org/impeach/him.rhtml
+ATTACH:http://corporations-dominate.existence.net/why.rhtml
+RDATE;TZID=US-Mountain:20050121T170000,20050122T170000
+X-TEST-COMPONENT;QTEST="Hello, World":Shouldn't double double quotes
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20110118T211523Z
+UID:uid-1234-uid-4321
+DTSTART;TZID=US-Mountain:20110120T170000
+DTEND;TZID=US-Mountain:20110120T184500
+CLASS:PRIVATE
+GEO:37.386013;-122.0829322
+ORGANIZER:mailto:jmera@jmera.human
+PRIORITY:2
+SUMMARY:This is a very short summary.
+RDATE;TZID=US-Mountain:20110121T170000,20110122T170000
+END:VEVENT

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -35,12 +35,24 @@ describe Icalendar::Parser do
     context 'event.ics' do
       let(:fn) { 'event.ics' }
 
-      before { subject.component = Icalendar::Event.new }
+      before { subject.component_class = Icalendar::Event }
 
       it 'returns an array of events' do
         expect(subject.parse).to be_instance_of Array
         expect(subject.parse.count).to be 1
         expect(subject.parse[0]).to be_instance_of Icalendar::Event
+      end
+    end
+    context 'events.ics' do
+      let(:fn) { 'two_events.ics' }
+
+      before { subject.component_class = Icalendar::Event }
+
+      it 'returns an array of events' do
+        events = subject.parse
+        expect(events.count).to be 2
+        expect(events.first.uid).to eq("bsuidfortestabc123")
+        expect(events.last.uid).to eq("uid-1234-uid-4321")
       end
     end
   end


### PR DESCRIPTION
Proposed fix for #152 

__Problem:__
When parsing files with multiple components the very same
component instance is used for each _file_-component.
That caused _every_ component to be identical to the last component
in the file.

````
events = Icalendar::Event.parse("two_events.ics")
puts events
#<Icalendar::Event:0x007ffd09aa2d60>
#<Icalendar::Event:0x007ffd09aa2d60>
````

__Proposed solution:__
Instead of using the same component instance for each file_component
a new instance is getting created and added to the `components`-Array

This is a first draft. I would appreciate any comment and possible improvement.
Thanks for your time and help