### PR TITLE
Bug & patch: multibyte folding

### DIFF
--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -56,9 +56,37 @@ module Icalendar
       prop_name.gsub(/\Aip_/, '').gsub('_', '-').upcase
     end
 
-    def ical_fold(content_line)
-      split = content_line.split ''
-      [].tap { |a| a << split.shift(Icalendar::MAX_LINE_LENGTH).join until split.empty? }.join "\r\n "
+    def ical_fold(long_line, indent = "\x20")
+      # rfc2445 says:
+      # Lines of text SHOULD NOT be longer than 75 octets, excluding the line
+      # break. Long content lines SHOULD be split into a multiple line
+      # representations using a line "folding" technique. That is, a long
+      # line can be split between any two characters by inserting a CRLF
+      # immediately followed by a single linear white space character (i.e.,
+      # SPACE, US-ASCII decimal 32 or HTAB, US-ASCII decimal 9). Any sequence
+      # of CRLF followed immediately by a single linear white space character
+      # is ignored (i.e., removed) when processing the content type.
+      #
+      # Note the useage of "octets" and "characters": a line should not be longer
+      # than 75 octets, but you need to split between characters, not bytes.
+      # This is challanging with Unicode composing accents, for example.
+
+      chars = long_line.scan(/\P{M}\p{M}*/u) # split in graphenes
+      folded = ['']
+      bytes = 0
+      while chars.count > 0
+        c = chars.shift
+        cb = c.bytes.count
+        if bytes + cb > Icalendar::MAX_LINE_LENGTH
+          # Split here
+          folded.push "#{indent}"
+          bytes = indent.bytes.count
+        end
+        folded[-1] += c
+        bytes += cb
+      end
+
+      folded.join("\r\n")
     end
 
     def ical_components

--- a/spec/fixtures/single_event.ics
+++ b/spec/fixtures/single_event.ics
@@ -12,7 +12,8 @@ GEO:37.386013;-122.0829322
 ORGANIZER:mailto:joebob@random.net
 PRIORITY:2
 SUMMARY:This is a really long summary to test the method of unfolding lines
- \, so I'm just going to make it a whole bunch of lines.
+ \, so I'm just going to make it a whole bunch of lines. With a twist: a "
+ ö" takes up multiple bytes\, and should be wrapped to the next line.
 ATTACH:http://bush.sucks.org/impeach/him.rhtml
 ATTACH:http://corporations-dominate.existence.net/why.rhtml
 RDATE;TZID=US-Mountain:20050121T170000,20050122T170000


### PR DESCRIPTION
I believe the folding implementation (`ical_fold` in `component.rb`) is incorrect when folding lines that contain non-ASCII characters. This pull request adds a test-case to demonstrate the issue, and patches the `ical_fold` method to fold correctly (according to my understanding of the RFC).

I am still unclear on what RFC2445 refers to as a `character` in the Unicode sense. This Pull Request errs on the side of caution and interprets `character` as meaning a grapheme (i.e. a `LATIN SMALL LETTER E`, followed by a `COMBINING ACUTE ACCENT` is considered 1 character. The corresponding 3 bytes of UTF-8 is thus always kept on the same line.