### PR TITLE
Don't rewind source

### DIFF
--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -14,12 +14,10 @@ module Icalendar
         Icalendar.fatal msg
         fail ArgumentError, msg
       end
-      read_in_data
       @strict = strict
     end
 
     def parse
-      source.rewind
       read_in_data
       components = []
       while (fields = next_fields)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -9,9 +9,10 @@ describe Icalendar::Parser do
       let(:fn) { 'single_event.ics' }
 
       it 'returns an array of calendars' do
-        expect(subject.parse).to be_instance_of Array
-        expect(subject.parse.count).to eq 1
-        expect(subject.parse[0]).to be_instance_of Icalendar::Calendar
+        parsed = subject.parse
+        expect(parsed).to be_instance_of Array
+        expect(parsed.count).to eq 1
+        expect(parsed[0]).to be_instance_of Icalendar::Calendar
       end
 
       it 'properly splits multi-valued lines' do
@@ -38,9 +39,10 @@ describe Icalendar::Parser do
       before { subject.component = Icalendar::Event.new }
 
       it 'returns an array of events' do
-        expect(subject.parse).to be_instance_of Array
-        expect(subject.parse.count).to be 1
-        expect(subject.parse[0]).to be_instance_of Icalendar::Event
+        parsed = subject.parse
+        expect(parsed).to be_instance_of Array
+        expect(parsed.count).to be 1
+        expect(parsed[0]).to be_instance_of Icalendar::Event
       end
     end
   end
@@ -49,9 +51,10 @@ describe Icalendar::Parser do
     let(:fn) { 'single_event_bad_line.ics' }
 
     it 'returns an array of calendars' do
-      expect(subject.parse).to be_instance_of Array
-      expect(subject.parse.count).to eq 1
-      expect(subject.parse[0]).to be_instance_of Icalendar::Calendar
+      parsed = subject.parse
+      expect(parsed).to be_instance_of Array
+      expect(parsed.count).to eq 1
+      expect(parsed[0]).to be_instance_of Icalendar::Calendar
     end
 
     it 'properly splits multi-valued lines' do


### PR DESCRIPTION
Avoid rewinding the input IO stream, as this breaks reading in from a
FIFO (named or shell pipe).