### PR TITLE
Fixed typo Icalender.parse -> Icalendar.parse.

### DIFF
--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -13,7 +13,7 @@ module Icalendar
   end
 
   def self.parse(source, single = false)
-    warn "**** DEPRECATION WARNING ****\nIcalender.parse will be removed. Please switch to Icalendar::Calendar.parse."
+    warn "**** DEPRECATION WARNING ****\nIcalendar.parse will be removed. Please switch to Icalendar::Calendar.parse."
     calendars = Parser.new(source).parse
     single ? calendars.first : calendars
   end


### PR DESCRIPTION
Fixed typo Icalender.parse -> Icalendar.parse.