### PR TITLE
Refactors date/date_time classes for DRYness

### DIFF
--- a/lib/icalendar/values/comparable_dates.rb
+++ b/lib/icalendar/values/comparable_dates.rb
@@ -1,0 +1,13 @@
+module Icalendar
+  module Values
+    module ComparableDates
+      def <=>(other)
+        if other.is_a?(Icalendar::Values::Date) || other.is_a?(Icalendar::Values::DateTime)
+          value_ical <=> other.value_ical
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/icalendar/values/date.rb
+++ b/lib/icalendar/values/date.rb
@@ -1,20 +1,19 @@
 require 'date'
+require_relative 'comparable_dates'
+require_relative 'parsable_dates'
 
 module Icalendar
   module Values
 
     class Date < Value
+      include ComparableDates
+      include ParsableDates
+
       FORMAT = '%Y%m%d'
 
       def initialize(value, params = {})
         if value.is_a? String
-          begin
-            parsed_date = ::Date.strptime(value, FORMAT)
-          rescue ArgumentError => e
-            raise FormatError.new("Failed to parse \"#{value}\" - #{e.message}")
-          end
-
-          super parsed_date, params
+          parsing(value, FORMAT) { |parsed_date| super(parsed_date, params) }
         elsif value.respond_to? :to_date
           super value.to_date, params
         else
@@ -33,10 +32,6 @@ module Icalendar
           nil
         end
       end
-
-      class FormatError < ArgumentError
-      end
     end
-
   end
 end

--- a/lib/icalendar/values/date_time.rb
+++ b/lib/icalendar/values/date_time.rb
@@ -1,10 +1,14 @@
 require 'date'
+require_relative 'comparable_dates'
+require_relative 'parsable_dates'
 require_relative 'time_with_zone'
 
 module Icalendar
   module Values
 
     class DateTime < Value
+      include ComparableDates
+      include ParsableDates
       include TimeWithZone
 
       FORMAT = '%Y%m%dT%H%M%S'
@@ -13,13 +17,7 @@ module Icalendar
         if value.is_a? String
           params['tzid'] = 'UTC' if value.end_with? 'Z'
 
-          begin
-            parsed_date = ::DateTime.strptime(value, FORMAT)
-          rescue ArgumentError => e
-            raise FormatError.new("Failed to parse \"#{value}\" - #{e.message}")
-          end
-
-          super parsed_date, params
+          parsing(value, FORMAT) { |parsed_date| super(parsed_date, params) }
         elsif value.respond_to? :to_datetime
           super value.to_datetime, params
         else
@@ -34,18 +32,6 @@ module Icalendar
           strftime FORMAT
         end
       end
-
-      def <=>(other)
-        if other.is_a?(Icalendar::Values::Date) || other.is_a?(Icalendar::Values::DateTime)
-          value_ical <=> other.value_ical
-        else
-          nil
-        end
-      end
-
-      class FormatError < ArgumentError
-      end
     end
-
   end
 end

--- a/lib/icalendar/values/parsable_dates.rb
+++ b/lib/icalendar/values/parsable_dates.rb
@@ -1,0 +1,14 @@
+module Icalendar
+  module Values
+    module ParsableDates
+      def parsing(value, format, &block)
+        yield ::DateTime.strptime(value, format)
+      rescue ArgumentError => e
+        raise FormatError.new("Failed to parse \"#{value}\" - #{e.message}")
+      end
+
+      class FormatError < ArgumentError
+      end
+    end
+  end
+end


### PR DESCRIPTION
  - `ComparableDates` addresses the identical `Comparable` implementation
    shared between icalendar's `Date` and `DateTime` classes
  - `ParsableDates` addresses the identical parse/rescue/reraise behavior
    shared between icalendar's `Date` and `DateTime` classes