### PR TITLE
add modern rubies, drop old rubies from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.4
+  - 2.3
   - 2.2
-  - 2.1
-  - 2.0
   - jruby-19mode
   - rbx-2
   - ruby-head
@@ -15,4 +14,5 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-2
 script: bundle exec rake spec


### PR DESCRIPTION
This updates the travis matrix to cover current 2.3 and 2.4 versions and removes unsupported ruby 2.0 and 2.1.

Commit 97ed9d301448350de15da4ba3b2323bd685d358c added a test that fails on ruby 2.1 and 2.0.  It appears we're catching something that's different (if not wrong) in older versions of the ruby stdlib.  Since those ruby versions are no longer supported, I think it's fair to drop them from the build matrix rather than working around it.