### PR TITLE
Start testing with Ruby 2.5 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
   - jruby-head
 matrix:
   allow_failures:
+    - rvm: 2.2
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
+  - 2.5
   - 2.4
   - 2.3
   - 2.2


### PR DESCRIPTION
Ruby 2.2 also moved to a best-effort support level as it is past end-of-life.