### PR TITLE
Remove reference to 2.x series being WIP on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,6 @@ iCalendar -- Internet calendaring, Ruby style
 
 <http://github.com/icalendar/icalendar>
 
-2.x Status
----
-
-iCalendar 2.0 is under active development, and can be followed in the
-[master branch](https://github.com/icalendar/icalendar/tree/master).
-
-iCalendar 1.x (currently the 1.x branch) will still survive for a
-while, but will only be accepting bug fixes from this point forward
-unless someone else wants to take over more active maintainership of
-the 1.x series.
-
-### 2.0 Goals ###
-
-* Implements [RFC 5545](http://tools.ietf.org/html/rfc5545)
-* More obvious access to parameters and values
-* Cleaner & easier timezone support
-
 ### Upgrade from 1.x ###
 
 Better documentation is still to come, but in the meantime the changes needed to move from 1.x to 2.0 are summarized by the [diff needed to update the README](https://github.com/icalendar/icalendar/commit/bc3701e004c915a250054030a9375d1e7618857f)


### PR DESCRIPTION
It's been ~5 years since this section of the README changed and several years of 2.x releases on rubygems, so I think removing this stanza is better than leaving it in, since it almost scared me off from using the library and resulted in more spelunking than I bargained for.

Library looks great, though!