### PR TITLE
Local timezone store

### DIFF
--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -21,6 +21,7 @@ module Icalendar
     end
 
     def parse
+      TimezoneStore.reset
       components = []
       while (fields = next_fields)
         component = component_class.new

--- a/lib/icalendar/timezone.rb
+++ b/lib/icalendar/timezone.rb
@@ -80,7 +80,7 @@ module Icalendar
             s.add_recurrence_rule IceCube::Rule.from_ical(rule.value_ical)
           end
           std.rdate.each do |date|
-            s.add_recurrence_date date
+            s.add_recurrence_time date.to_time
           end
         end
         [schedule.previous_occurrence(local.to_time), std]
@@ -95,7 +95,7 @@ module Icalendar
             s.add_recurrence_rule IceCube::Rule.from_ical(rule.value_ical)
           end
           day.rdate.each do |date|
-            s.add_recurrence_date date
+            s.add_recurrence_time date.to_time
           end
         end
         [schedule.previous_occurrence(local.to_time), day]

--- a/lib/icalendar/timezone_store.rb
+++ b/lib/icalendar/timezone_store.rb
@@ -9,7 +9,13 @@ module Icalendar
     end
 
     def self.instance
-      @instance ||= new
+      Thread.current[:timezone_store] ||= new
+    end
+    def self.instance=(store)
+      Thread.current[:timezone_store] = store
+    end
+    def self.reset
+      instance = nil
     end
 
     def self.store(timezone)

--- a/spec/tzinfo_spec.rb
+++ b/spec/tzinfo_spec.rb
@@ -29,7 +29,6 @@ describe 'TZInfo::Timezone' do
     let(:tz) { TZInfo::Timezone.get 'Asia/Shanghai' }
     let(:date) { DateTime.now }
 
-    # TODO only run this test with tzinfo ≥ 1.0
     it 'only creates a standard component' do
       expect(subject.to_ical).to eq <<-EXPECTED.gsub "\n", "\r\n"
 BEGIN:VTIMEZONE


### PR DESCRIPTION
Scopes `TimezoneStore` to a thread local variable, and reset on each call of `Parser#parse`

This addresses part of the issue on #192, but not the part where the VTIMEZONE must be parsed before the VEVENT that references it.