### PR TITLE
Local timezone store

### DIFF
--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -13,7 +13,7 @@ module Icalendar
   end
 
   def self.parse(source, single = false)
-    warn "**** DEPRECATION WARNING ****\nIcalendar.parse will be removed. Please switch to Icalendar::Calendar.parse."
+    warn "**** DEPRECATION WARNING ****\nIcalendar.parse will be removed in 3.0. Please switch to Icalendar::Calendar.parse."
     calendars = Parser.new(source).parse
     single ? calendars.first : calendars
   end

--- a/lib/icalendar/timezone_store.rb
+++ b/lib/icalendar/timezone_store.rb
@@ -9,6 +9,7 @@ module Icalendar
     end
 
     def self.instance
+      warn "**** DEPRECATION WARNING ****\nTimezoneStore.instance will be removed in 3.0. Please instantiate a TimezoneStore object."
       @instance ||= new
     end
 

--- a/lib/icalendar/values/array.rb
+++ b/lib/icalendar/values/array.rb
@@ -22,7 +22,7 @@ module Icalendar
                  else
                    [klass.new(value, params)]
                  end
-        super mapped, params
+        super mapped
       end
 
       def params_ical

--- a/lib/icalendar/values/date.rb
+++ b/lib/icalendar/values/date.rb
@@ -7,6 +7,8 @@ module Icalendar
       FORMAT = '%Y%m%d'
 
       def initialize(value, params = {})
+        params.delete 'tzid'
+        params.delete 'x-tz-info'
         if value.is_a? String
           begin
             parsed_date = ::Date.strptime(value, FORMAT)

--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -18,6 +18,7 @@ module Icalendar
       def initialize(value, params = {})
         params = Icalendar::DowncasedHash(params)
         @tz_utc = params['tzid'] == 'UTC'
+        x_tz_info = params.delete 'x-tz-info'
 
         offset_value = unless params['tzid'].nil?
           tzid = params['tzid'].is_a?(::Array) ? params['tzid'].first : params['tzid']
@@ -25,12 +26,12 @@ module Icalendar
               defined?(ActiveSupportTimeWithZoneAdapter) &&
               (tz = ActiveSupport::TimeZone[tzid])
             ActiveSupportTimeWithZoneAdapter.new(nil, tz, value)
-          elsif (tz = TimezoneStore.retrieve(tzid))
-            offset = tz.offset_for_local(value).to_s
+          elsif !x_tz_info.nil?
+            offset = x_tz_info.offset_for_local(value).to_s
             if value.respond_to?(:change)
               value.change offset: offset
             else
-              ::Time.new(value.year, value.month, value.day, value.hour, value.min, value.sec, offset)
+              ::Time.new value.year, value.month, value.day, value.hour, value.min, value.sec, offset
             end
           end
         end

--- a/spec/roundtrip_spec.rb
+++ b/spec/roundtrip_spec.rb
@@ -15,7 +15,7 @@ describe Icalendar do
       parsed = Icalendar::Calendar.parse(source).first
       event.rdate = parsed.events.first.rdate
       expect(event.rdate.first).to be_kind_of Icalendar::Values::Array
-      expect(event.rdate.first.ical_params).to eq 'tzid' => ['US-Mountain']
+      expect(event.rdate.first.params_ical).to eq ";TZID=US-Mountain"
     end
   end
 

--- a/spec/tzinfo_spec.rb
+++ b/spec/tzinfo_spec.rb
@@ -29,7 +29,6 @@ describe 'TZInfo::Timezone' do
     let(:tz) { TZInfo::Timezone.get 'Asia/Shanghai' }
     let(:date) { DateTime.now }
 
-    # TODO only run this test with tzinfo ≥ 1.0
     it 'only creates a standard component' do
       expect(subject.to_ical).to eq <<-EXPECTED.gsub "\n", "\r\n"
 BEGIN:VTIMEZONE


### PR DESCRIPTION
Scopes TimezoneStore to a local variable in the parser.

This addresses part of the issue on #192, but not the part where the VTIMEZONE must be parsed before the VEVENT that references it.