### PR TITLE
A very simple, major performance improvement when parsing

### DIFF
--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -172,7 +172,11 @@ module Icalendar
           end
         end
       end
-      Icalendar.logger.debug "Found fields: #{parts.inspect} with params: #{params.inspect}"
+      # Building the string to send to the logger is expensive.
+      # Only do it if the logger is at the right log level.
+      if ::Logger::DEBUG >= Icalendar.logger.level
+        Icalendar.logger.debug "Found fields: #{parts.inspect} with params: #{params.inspect}"
+      end
       {
         name: parts[:name].downcase.gsub('-', '_'),
         params: params,


### PR DESCRIPTION
First I want thank you very much for this gem.  Being able to work with iCalendar data in Ruby is wonderful.

Sometimes I have to parse somewhat large and complex iCalendar data and in some situations this gem can be slow.  I just ran across a situation parsing a 3.5 MB file with 5k+ events where the gem ran for 20 minutes before I gave up and killed it.

So I ran the code through `ruby-prof` and it pointed me to this line of code:
https://github.com/icalendar/icalendar/blob/471fa2e7076bdfe2715834273b93eb039591aabf/lib/icalendar/parser.rb#L175

As you can see in the ruby-prof call stack graph, coercing `parts` and `params` into a string to send to the logger accounted for over 97% of the runtime:
![image](https://user-images.githubusercontent.com/228009/50602020-18705e00-0e84-11e9-870a-3cfb21fb7194.png)

So this PR simply checks to see if the logger is at the debug level before wasting time building a string that will get thrown away.

With this change my file that originally was taking 20+ minutes to parse (before I gave up) now parses in about 6 seconds.