### PR TITLE
Speed up parsing by calling logger conditionally.

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+=== 2.5.3 2019-03-01
+ * Speed up parsing by calling logger conditionally.
+
 === 2.5.2 2018-12-08
  * Remove usage of the global TimezoneStore instance, in favor of a local variable in the parser
  * Deprecate TimezoneStore class methods

--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -172,7 +172,8 @@ module Icalendar
           end
         end
       end
-      Icalendar.logger.debug "Found fields: #{parts.inspect} with params: #{params.inspect}"
+      # `inspect` calls are expensive, skip them when logger not in debug mode.
+      Icalendar.logger.debug "Found fields: #{parts.inspect} with params: #{params.inspect}" if Icalendar.logger.level == ::Logger::DEBUG
       {
         name: parts[:name].downcase.gsub('-', '_'),
         params: params,

--- a/lib/icalendar/version.rb
+++ b/lib/icalendar/version.rb
@@ -1,5 +1,5 @@
 module Icalendar
 
-  VERSION = '2.5.2'
+  VERSION = '2.5.3'
 
 end


### PR DESCRIPTION
Hi :wave:

I started using the icalendar gem for a project and it worked as expected which was great! 🎉 

I also noticed it was slow, a calendar with 267 events would take 18 seconds to be parsed.

I used the following snippet to perform an investigation on this issue:

```ruby
require 'ruby-prof'
ical = File.read('spec/fixtures/calendar.ics')
result = RubyProf.profile do
  Icalendar::Calendar.parse(ical).first
end
printer = RubyProf::FlatPrinter.new(result)
printer.print(STDOUT)
```

The report would state that `String#inspect` and `Delegator#method_missing` were taking a meaningful chunk of the parsing time. While accurate it was not that helpful so I started poking around the code, commenting and uncommenting some chunks of code, until I found the main reason for the parsing to be slow: logger calls to debug events.

After adding this conditional logger call the calendar is now parsed in under a second. I also tested the call with `Logger::DEBUG` level and it took ~ 4 minutes because of all the `IO#write`, which is expected. In every scenario I used the same calendar.

Thanks for sharing your project and considering my contribution. :purple_heart: