### PR TITLE
Revert "Make it possible to de/serialize using Marshal so you can store parsed icalendar in Rail's cache"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ pkg/
 .bundle
 coverage/
 tags
-.idea

--- a/lib/icalendar/has_components.rb
+++ b/lib/icalendar/has_components.rb
@@ -10,7 +10,7 @@ module Icalendar
     end
 
     def initialize(*args)
-      @custom_components = Hash.new
+      @custom_components = Hash.new { |h, k| h[k] = [] }
       super
     end
 
@@ -26,7 +26,7 @@ module Icalendar
       if method_name =~ /^add_(x_\w+)$/
         component_name = $1
         custom = args.first || Component.new(component_name, component_name.upcase)
-        (custom_components[component_name] ||= []) << custom
+        custom_components[component_name] << custom
         yield custom if block_given?
         custom
       else

--- a/lib/icalendar/has_properties.rb
+++ b/lib/icalendar/has_properties.rb
@@ -10,7 +10,7 @@ module Icalendar
     end
 
     def initialize(*args)
-      @custom_properties = Hash.new
+      @custom_properties = Hash.new { |h, k| h[k] = [] }
       super
     end
 
@@ -49,9 +49,9 @@ module Icalendar
       elsif self.class.multiple_properties.include? property_name
         send "append_#{property_name}", value
       elsif value.is_a? Icalendar::Value
-        (custom_properties[property_name] ||= []) << value
+        custom_properties[property_name] << value
       else
-        (custom_properties[property_name] ||= []) << Icalendar::Values::Text.new(value)
+        custom_properties[property_name] << Icalendar::Values::Text.new(value)
       end
     end
 

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -2,12 +2,6 @@ require 'spec_helper'
 
 describe Icalendar::Calendar do
 
-  context 'marshalling' do
-    it 'can be de/serialized' do
-      Marshal.load(Marshal.dump(subject))
-    end
-  end
-
   context 'values' do
     let(:property) { 'my-value' }
 


### PR DESCRIPTION
Reverts icalendar/icalendar#212

This changes the behavior of requesting custom components that weren't in the original file in a way that I'm not comfortable doing outside of a major revision.

Before the change calling `event.x_doesnt_exist` would return `[]`

After the change calling `event.x_doesnt_exist` returns `nil`