### PR TITLE
Make it possible to de/serialize using Marshal so you can store parsed icalendar in Rail's cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg/
 .bundle
 coverage/
 tags
+.idea

--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -22,6 +22,7 @@ end
 
 require 'icalendar/has_properties'
 require 'icalendar/has_components'
+require 'icalendar/marshable'
 require 'icalendar/component'
 require 'icalendar/value'
 require 'icalendar/alarm'

--- a/lib/icalendar/has_components.rb
+++ b/lib/icalendar/has_components.rb
@@ -10,7 +10,7 @@ module Icalendar
     end
 
     def initialize(*args)
-      @custom_components = Hash.new { |h, k| h[k] = [] }
+      @custom_components = Hash.new
       super
     end
 
@@ -26,7 +26,7 @@ module Icalendar
       if method_name =~ /^add_(x_\w+)$/
         component_name = $1
         custom = args.first || Component.new(component_name, component_name.upcase)
-        custom_components[component_name] << custom
+        (custom_components[component_name] ||= []) << custom
         yield custom if block_given?
         custom
       else

--- a/lib/icalendar/has_properties.rb
+++ b/lib/icalendar/has_properties.rb
@@ -10,7 +10,7 @@ module Icalendar
     end
 
     def initialize(*args)
-      @custom_properties = Hash.new { |h, k| h[k] = [] }
+      @custom_properties = Hash.new
       super
     end
 
@@ -39,7 +39,7 @@ module Icalendar
     end
 
     def custom_property(property_name)
-      custom_properties[property_name.downcase]
+      custom_properties[property_name.downcase] || []
     end
 
     def append_custom_property(property_name, value)
@@ -49,9 +49,9 @@ module Icalendar
       elsif self.class.multiple_properties.include? property_name
         send "append_#{property_name}", value
       elsif value.is_a? Icalendar::Value
-        custom_properties[property_name] << value
+        (custom_properties[property_name] ||= []) << value
       else
-        custom_properties[property_name] << Icalendar::Values::Text.new(value)
+        (custom_properties[property_name] ||= []) << Icalendar::Values::Text.new(value)
       end
     end
 

--- a/lib/icalendar/marshable.rb
+++ b/lib/icalendar/marshable.rb
@@ -1,0 +1,34 @@
+module Icalendar
+  module Marshable
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    def marshal_dump
+      instance_variables
+        .reject { |ivar| self.class.transient_variables.include?(ivar) }
+        .each_with_object({}) do |ivar, serialized|
+
+        serialized[ivar] = instance_variable_get(ivar)
+      end
+    end
+
+    def marshal_load(serialized)
+      serialized.each do |ivar, value|
+        unless self.class.transient_variables.include?(ivar)
+          instance_variable_set(ivar, value)
+        end
+      end
+    end
+
+    module ClassMethods
+      def transient_variables
+        @transient_variables ||= [:@transient_variables]
+      end
+
+      def transient_variable(name)
+        transient_variables.push(name.to_sym)
+      end
+    end
+  end
+end

--- a/lib/icalendar/timezone.rb
+++ b/lib/icalendar/timezone.rb
@@ -14,6 +14,9 @@ module Icalendar
           optional_property :comment
           optional_property :rdate, Icalendar::Values::DateTime
           optional_property :tzname
+
+          transient_variable :@cached_occurrences
+          transient_variable :@occurrences
         end
       end
 
@@ -44,6 +47,7 @@ module Icalendar
       end
     end
     class Daylight < Component
+      include Marshable
       include TzProperties
 
       def initialize
@@ -51,6 +55,7 @@ module Icalendar
       end
     end
     class Standard < Component
+      include Marshable
       include TzProperties
 
       def initialize

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 describe Icalendar::Calendar do
 
+  context 'marshalling' do
+    it 'can be de/serialized' do
+      Marshal.load(Marshal.dump(subject))
+    end
+  end
+
   context 'values' do
     let(:property) { 'my-value' }
 

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -113,6 +113,13 @@ describe Icalendar::Event do
     end
   end
 
+  describe "#custom_property" do
+    it "returns a default for missing properties" do
+      expect(subject.x_doesnt_exist).to eq([])
+      expect(subject.custom_property "x_doesnt_exist").to eq([])
+    end
+  end
+
   describe '.parse' do
     let(:source) { File.read File.join(File.dirname(__FILE__), 'fixtures', fn) }
     let(:fn) { 'event.ics' }

--- a/spec/timezone_spec.rb
+++ b/spec/timezone_spec.rb
@@ -28,4 +28,52 @@ describe Icalendar::Timezone do
       it { should_not be_valid }
     end
   end
+
+  context 'marshalling' do
+    context 'with standard/daylight components' do
+      before do
+        subject.standard do |standard|
+          standard.rrule = Icalendar::Values::Recur.new("FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=10")
+          standard.dtstart = Icalendar::Values::DateTime.new("16010101T030000")
+          standard.tzoffsetfrom = Icalendar::Values::UtcOffset.new("+0200")
+          standard.tzoffsetto = Icalendar::Values::UtcOffset.new("+0100")
+        end
+
+        subject.daylight do |daylight|
+          daylight.rrule = Icalendar::Values::Recur.new("FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=3")
+          daylight.dtstart = Icalendar::Values::DateTime.new("16010101T020000")
+          daylight.tzoffsetfrom = Icalendar::Values::UtcOffset.new("+0100")
+          daylight.tzoffsetto = Icalendar::Values::UtcOffset.new("+0200")
+        end
+      end
+
+      it 'can be de/serialized' do
+        first_standard = subject.standards.first
+        first_daylight = subject.daylights.first
+
+        expect(first_standard.valid?).to be_truthy
+        expect(first_daylight.valid?).to be_truthy
+
+        # calling previous_occurrence intializes @cached_occurrences with a time that's not handled by ruby marshaller
+        first_occurence_for = Time.new(1601, 10, 31)
+
+        standard_previous_occurrence = first_standard.previous_occurrence(first_occurence_for)
+        expect(standard_previous_occurrence).not_to be_nil
+
+        daylight_previous_occurrence = first_daylight.previous_occurrence(first_occurence_for)
+        expect(daylight_previous_occurrence).not_to be_nil
+
+        deserialized = nil
+
+        expect { deserialized = Marshal.load(Marshal.dump(subject)) }.not_to raise_exception
+
+        expect(deserialized.standards.first.previous_occurrence(first_occurence_for)).to eq(standard_previous_occurrence)
+        expect(deserialized.daylights.first.previous_occurrence(first_occurence_for)).to eq(daylight_previous_occurrence)
+      end
+    end
+
+    it 'can be de/serialized' do
+      expect { Marshal.load(Marshal.dump(subject)) }.not_to raise_exception
+    end
+  end
 end


### PR DESCRIPTION
Follow up for https://github.com/icalendar/icalendar/pull/212 with fixed behavior in `has_properties.rb` (fixes https://github.com/icalendar/icalendar/pull/216)

Also added another commit extending `.gitignore` with `.idea` hope you don't mind (I don't put it into global git ignore because we actually version .idea for internal projects).