### PR TITLE
Optimise Icalendar::Component#ical_fold

### DIFF
--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -71,6 +71,8 @@ module Icalendar
       # than 75 octets, but you need to split between characters, not bytes.
       # This is challanging with Unicode composing accents, for example.
 
+      return long_line if long_line.bytesize <= Icalendar::MAX_LINE_LENGTH
+
       chars = long_line.scan(/\P{M}\p{M}*/u) # split in graphenes
       folded = ['']
       bytes = 0


### PR DESCRIPTION
I think that if the string given to #ical_fold is short enough (by bytes) already then we can avoid splitting it by graphemes and looping over each character checking its byte size as we go?

We're generating quite large ICS files for some of our customers at CharlieHR and we've found it can be a bit slow. In testing on my dev laptop, using ruby-prof, I found a case where this had a performance improvement of ~30% (from 10 seconds to 7 seconds).