### PR TITLE
Adding license information to the gemspec.

### DIFF
--- a/icalendar.gemspec
+++ b/icalendar.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
 
   s.name = "icalendar"
   s.version = Icalendar::VERSION
+  s.licenses = ['BSD-2-Clause', 'GPL-3.0-only', 'icalendar']
 
   s.homepage = "https://github.com/icalendar/icalendar"
   s.platform = Gem::Platform::RUBY


### PR DESCRIPTION
Tools like VersionEye are using these information for license compliance analysis.

Ruby itself is currently using the BDS-2-Clause license, which is compatible to GPL. Older versions of the BSD, like the BSD-4-Clause, are NOT compatible to the GPL license. GPL itself has many different versions. I picked here the current one with GPL-3.0-only. There is a GPL-3.0-or-later as well, but with that you have to accept any upcoming version as well, which you don't know about yet. That's why I would recommend to fix it to 3.0! 
As third license I added `icalendar`, which simply identifies the LICENSE file in this repository. 