### PR TITLE
activesupport v7 require changes.

### DIFF
--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -6,6 +6,12 @@ begin
   if defined?(ActiveSupport::TimeWithZone)
     require 'icalendar/values/active_support_time_with_zone_adapter'
   end
+rescue NameError
+  # ActiveSupport v7+ needs the base require to be run first before loading
+  # specific parts of it.
+  # https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support
+  require 'active_support'
+  retry
 rescue LoadError
   # tis ok, just a bit less fancy
 end


### PR DESCRIPTION
As of v7.0.0 - even when you only want to use part of ActiveSupport, you must require the main file, and then load the parts you want. The relevant documentation:
https://guides.rubyonrails.org/active_support_core_extensions.html\#stand-alone-active-support

It seems it no longer loads every single monkeypatch by default, so this change should still keep things as minimal as desired.