### PR TITLE
Change URL on VEVENT to generate using the ;VALUE=URI syntax, like VCALENDAR.

### DIFF
--- a/lib/icalendar/event.rb
+++ b/lib/icalendar/event.rb
@@ -24,7 +24,7 @@ module Icalendar
     optional_single_property :status
     optional_single_property :summary
     optional_single_property :transp
-    optional_single_property :url, Icalendar::Values::Uri
+    optional_single_property :url, Icalendar::Values::Uri, true
     optional_single_property :recurrence_id, Icalendar::Values::DateTime
 
     optional_property :rrule, Icalendar::Values::Recur, true

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -156,6 +156,7 @@ describe Icalendar::Event do
       subject.dtend = "20131227T033000Z"
       subject.summary = 'My event, my ical, my test'
       subject.geo = [41.230896,-74.411774]
+      subject.url = 'https://example.com'
       subject.x_custom_property = 'customize'
     end
 
@@ -163,6 +164,7 @@ describe Icalendar::Event do
     it { expect(subject.to_ical).to include 'DTEND:20131227T033000Z' }
     it { expect(subject.to_ical).to include 'SUMMARY:My event\, my ical\, my test' }
     it { expect(subject.to_ical).to include 'X-CUSTOM-PROPERTY:customize' }
+    it { expect(subject.to_ical).to include 'URL;VALUE=URI:https://example.com' }
     it { expect(subject.to_ical).to include 'GEO:41.230896;-74.411774' }
 
     context 'simple organizer' do


### PR DESCRIPTION
I noticed with some experimentation that Apple Calendar, at least, would not identify URLs set on events without this parameter (and that events that it generates have it set this way too).

I noticed that you already use this parameter when generating URLs for the calendar object, so I figure this is also improving the consistency of the behavior.