### PR TITLE
2.29x Performance Increase: Freeze Regexes & add `frozen_string_literal` magic comments

### DIFF
--- a/lib/icalendar.rb
+++ b/lib/icalendar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'icalendar/logger'
 
 module Icalendar

--- a/lib/icalendar/alarm.rb
+++ b/lib/icalendar/alarm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   class Alarm < Component

--- a/lib/icalendar/calendar.rb
+++ b/lib/icalendar/calendar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   class Calendar < Component

--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module Icalendar

--- a/lib/icalendar/component.rb
+++ b/lib/icalendar/component.rb
@@ -53,9 +53,13 @@ module Icalendar
       end.compact.join "\r\n"
     end
 
+    ICAL_PROP_NAME_GSUB_REGEX = /\Aip_/.freeze
+
     def ical_prop_name(prop_name)
-      prop_name.gsub(/\Aip_/, '').gsub('_', '-').upcase
+      prop_name.gsub(ICAL_PROP_NAME_GSUB_REGEX, '').gsub('_', '-').upcase
     end
+
+    ICAL_FOLD_LONG_LINE_SCAN_REGEX = /\P{M}\p{M}*/u.freeze
 
     def ical_fold(long_line, indent = "\x20")
       # rfc2445 says:
@@ -74,7 +78,7 @@ module Icalendar
 
       return long_line if long_line.bytesize <= Icalendar::MAX_LINE_LENGTH
 
-      chars = long_line.scan(/\P{M}\p{M}*/u) # split in graphenes
+      chars = long_line.scan(ICAL_FOLD_LONG_LINE_SCAN_REGEX) # split in graphenes
       folded = ['']
       bytes = 0
       while chars.count > 0

--- a/lib/icalendar/downcased_hash.rb
+++ b/lib/icalendar/downcased_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 module Icalendar

--- a/lib/icalendar/event.rb
+++ b/lib/icalendar/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   class Event < Component

--- a/lib/icalendar/freebusy.rb
+++ b/lib/icalendar/freebusy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   class Freebusy < Component

--- a/lib/icalendar/has_components.rb
+++ b/lib/icalendar/has_components.rb
@@ -32,13 +32,16 @@ module Icalendar
       custom_components[component_name.downcase.gsub("-", "_")] || []
     end
 
+    METHOD_MISSING_ADD_REGEX = /^add_(x_\w+)$/.freeze
+    METHOD_MISSING_X_FLAG_REGEX = /^x_/.freeze
+
     def method_missing(method, *args, &block)
       method_name = method.to_s
-      if method_name =~ /^add_(x_\w+)$/
+      if method_name =~ METHOD_MISSING_ADD_REGEX
         component_name = $1
         custom = args.first || Component.new(component_name, component_name.upcase)
         add_custom_component(component_name, custom, &block)
-      elsif method_name =~ /^x_/ && custom_component(method_name).size > 0
+      elsif method_name =~ METHOD_MISSING_X_FLAG_REGEX && custom_component(method_name).size > 0
         custom_component method_name
       else
         super

--- a/lib/icalendar/has_components.rb
+++ b/lib/icalendar/has_components.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   module HasComponents

--- a/lib/icalendar/has_properties.rb
+++ b/lib/icalendar/has_properties.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   module HasProperties

--- a/lib/icalendar/journal.rb
+++ b/lib/icalendar/journal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   class Journal < Component

--- a/lib/icalendar/logger.rb
+++ b/lib/icalendar/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 require 'logger'
 

--- a/lib/icalendar/marshable.rb
+++ b/lib/icalendar/marshable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Marshable
     def self.included(base)

--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'icalendar/timezone_store'
 
 module Icalendar

--- a/lib/icalendar/timezone.rb
+++ b/lib/icalendar/timezone.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ice_cube'
 
 module Icalendar

--- a/lib/icalendar/timezone_store.rb
+++ b/lib/icalendar/timezone_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 require 'icalendar/downcased_hash'
 

--- a/lib/icalendar/todo.rb
+++ b/lib/icalendar/todo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   class Todo < Component

--- a/lib/icalendar/tzinfo.rb
+++ b/lib/icalendar/tzinfo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 =begin
   Copyright (C) 2008 Sean Dague
 

--- a/lib/icalendar/value.rb
+++ b/lib/icalendar/value.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+
 require 'delegate'
 require 'icalendar/downcased_hash'
 

--- a/lib/icalendar/value.rb
+++ b/lib/icalendar/value.rb
@@ -31,8 +31,11 @@ module Icalendar
       end
     end
 
+    VALUE_TYPE_GSUB_REGEX_1 = /\A.*::/.freeze
+    VALUE_TYPE_GSUB_REGEX_2 = /(?<!\A)[A-Z]/.freeze
+
     def self.value_type
-      name.gsub(/\A.*::/, '').gsub(/(?<!\A)[A-Z]/, '-\0').upcase
+      name.gsub(VALUE_TYPE_GSUB_REGEX_1, '').gsub(VALUE_TYPE_GSUB_REGEX_2, '-\0').upcase
     end
 
     def value_type
@@ -54,9 +57,11 @@ module Icalendar
       "#{name.to_s.gsub('_', '-').upcase}=#{param_value}"
     end
 
+    ESCAPE_PARAM_VALUE_REGEX = /[;:,]/.freeze
+
     def escape_param_value(value)
       v = value.to_s.gsub('"', "'")
-      v =~ /[;:,]/ ? %("#{v}") : v
+      v =~ ESCAPE_PARAM_VALUE_REGEX ? %("#{v}") : v
     end
 
   end

--- a/lib/icalendar/values/active_support_time_with_zone_adapter.rb
+++ b/lib/icalendar/values/active_support_time_with_zone_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
     class ActiveSupportTimeWithZoneAdapter < ActiveSupport::TimeWithZone

--- a/lib/icalendar/values/array.rb
+++ b/lib/icalendar/values/array.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
 

--- a/lib/icalendar/values/binary.rb
+++ b/lib/icalendar/values/binary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module Icalendar

--- a/lib/icalendar/values/binary.rb
+++ b/lib/icalendar/values/binary.rb
@@ -21,9 +21,11 @@ module Icalendar
 
       private
 
+      BASE_64_REGEX = /\A(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}==)\z/.freeze
+
       def base64?
         value.is_a?(String) &&
-            value =~ /\A(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}==)\z/
+            value =~ BASE_64_REGEX
       end
     end
 

--- a/lib/icalendar/values/boolean.rb
+++ b/lib/icalendar/values/boolean.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
 

--- a/lib/icalendar/values/cal_address.rb
+++ b/lib/icalendar/values/cal_address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
 

--- a/lib/icalendar/values/date.rb
+++ b/lib/icalendar/values/date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 
 module Icalendar

--- a/lib/icalendar/values/date_time.rb
+++ b/lib/icalendar/values/date_time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 require_relative 'time_with_zone'
 

--- a/lib/icalendar/values/duration.rb
+++ b/lib/icalendar/values/duration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 module Icalendar

--- a/lib/icalendar/values/duration.rb
+++ b/lib/icalendar/values/duration.rb
@@ -36,14 +36,21 @@ module Icalendar
         hours > 0 || minutes > 0 || seconds > 0
       end
 
+      DURATION_PAST_REGEX = /\A([+-])P/.freeze
+      DURATION_WEEKS_REGEX = /(\d+)W/.freeze
+      DURATION_DAYS_REGEX = /(\d+)D/.freeze
+      DURATION_HOURS_REGEX = /(\d+)H/.freeze
+      DURATION_MINUTES_REGEX = /(\d+)M/.freeze
+      DURATION_SECONDS_REGEX = /(\d+)S/.freeze
+
       def parse_fields(value)
         {
-          past: (value =~ /\A([+-])P/ ? $1 == '-' : false),
-          weeks: (value =~ /(\d+)W/ ? $1.to_i : 0),
-          days: (value =~ /(\d+)D/ ? $1.to_i : 0),
-          hours: (value =~ /(\d+)H/ ? $1.to_i : 0),
-          minutes: (value =~ /(\d+)M/ ? $1.to_i : 0),
-          seconds: (value =~ /(\d+)S/ ? $1.to_i : 0)
+          past: (value =~ DURATION_PAST_REGEX ? $1 == '-' : false),
+          weeks: (value =~ DURATION_WEEKS_REGEX ? $1.to_i : 0),
+          days: (value =~ DURATION_DAYS_REGEX ? $1.to_i : 0),
+          hours: (value =~ DURATION_HOURS_REGEX ? $1.to_i : 0),
+          minutes: (value =~ DURATION_MINUTES_REGEX ? $1.to_i : 0),
+          seconds: (value =~ DURATION_SECONDS_REGEX ? $1.to_i : 0)
         }
       end
     end

--- a/lib/icalendar/values/float.rb
+++ b/lib/icalendar/values/float.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
 

--- a/lib/icalendar/values/integer.rb
+++ b/lib/icalendar/values/integer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
 

--- a/lib/icalendar/values/period.rb
+++ b/lib/icalendar/values/period.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
 

--- a/lib/icalendar/values/period.rb
+++ b/lib/icalendar/values/period.rb
@@ -3,10 +3,12 @@ module Icalendar
 
     class Period < Value
 
+      PERIOD_LAST_PART_REGEX = /\A[+-]?P.+\z/.freeze
+
       def initialize(value, params = {})
         parts = value.split '/'
         period_start = Icalendar::Values::DateTime.new parts.first
-        if parts.last =~ /\A[+-]?P.+\z/
+        if parts.last =~ PERIOD_LAST_PART_REGEX
           period_end = Icalendar::Values::Duration.new parts.last
         else
           period_end = Icalendar::Values::DateTime.new parts.last

--- a/lib/icalendar/values/recur.rb
+++ b/lib/icalendar/values/recur.rb
@@ -44,22 +44,37 @@ module Icalendar
 
       private
 
+      PARSE_FIELDS_FREQUENCY_REGEX = /FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)/i.freeze
+      PARSE_FIELDS_UNTIL_REGEX = /UNTIL=([^;]*)/i.freeze
+      PARSE_FIELDS_COUNT_REGEX = /COUNT=(\d+)/i.freeze
+      PARSE_FIELDS_INTERVAL_REGEX = /INTERVAL=(\d+)/i.freeze
+      PARSE_FIELDS_BY_SECOND_REGEX = /BYSECOND=(#{NUM_LIST})(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_MINUTE_REGEX = /BYMINUTE=(#{NUM_LIST})(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_HOUR_REGEX = /BYHOUR=(#{NUM_LIST})(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_DAY_REGEX = /BYDAY=(#{WEEKDAY}(?:,#{WEEKDAY})*)(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_MONTH_DAY_REGEX = /BYMONTHDAY=(#{MONTHDAY}(?:,#{MONTHDAY})*)(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_YEAR_DAY_REGEX = /BYYEARDAY=(#{YEARDAY}(?:,#{YEARDAY})*)(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_WEEK_NUMBER_REGEX = /BYWEEKNO=(#{MONTHDAY}(?:,#{MONTHDAY})*)(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_MONTH_REGEX = /BYMONTH=(#{NUM_LIST})(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_SET_POSITON_REGEX = /BYSETPOS=(#{YEARDAY}(?:,#{YEARDAY})*)(?:;|\z)/i.freeze
+      PARSE_FIELDS_BY_WEEK_START_REGEX = /WKST=(#{DAYNAME})/i.freeze
+
       def parse_fields(value)
         {
-          frequency: (value =~ /FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)/i ? $1.upcase : nil),
-          until: (value =~ /UNTIL=([^;]*)/i ? $1 : nil),
-          count: (value =~ /COUNT=(\d+)/i ? $1.to_i : nil),
-          interval: (value =~ /INTERVAL=(\d+)/i ? $1.to_i : nil),
-          by_second: (value =~ /BYSECOND=(#{NUM_LIST})(?:;|\z)/i ? $1.split(',').map { |i| i.to_i } : nil),
-          by_minute: (value =~ /BYMINUTE=(#{NUM_LIST})(?:;|\z)/i ? $1.split(',').map { |i| i.to_i } : nil),
-          by_hour: (value =~ /BYHOUR=(#{NUM_LIST})(?:;|\z)/i ? $1.split(',').map { |i| i.to_i } : nil),
-          by_day: (value =~ /BYDAY=(#{WEEKDAY}(?:,#{WEEKDAY})*)(?:;|\z)/i ? $1.split(',') : nil),
-          by_month_day: (value =~ /BYMONTHDAY=(#{MONTHDAY}(?:,#{MONTHDAY})*)(?:;|\z)/i ? $1.split(',') : nil),
-          by_year_day: (value =~ /BYYEARDAY=(#{YEARDAY}(?:,#{YEARDAY})*)(?:;|\z)/i ? $1.split(',') : nil),
-          by_week_number: (value =~ /BYWEEKNO=(#{MONTHDAY}(?:,#{MONTHDAY})*)(?:;|\z)/i ? $1.split(',') : nil),
-          by_month: (value =~ /BYMONTH=(#{NUM_LIST})(?:;|\z)/i ? $1.split(',').map { |i| i.to_i } : nil),
-          by_set_position: (value =~ /BYSETPOS=(#{YEARDAY}(?:,#{YEARDAY})*)(?:;|\z)/i ? $1.split(',') : nil),
-          week_start: (value =~ /WKST=(#{DAYNAME})/i ? $1.upcase : nil)
+          frequency: (value =~ PARSE_FIELDS_FREQUENCY_REGEX ? $1.upcase : nil),
+          until: (value =~ PARSE_FIELDS_UNTIL_REGEX ? $1 : nil),
+          count: (value =~ PARSE_FIELDS_COUNT_REGEX ? $1.to_i : nil),
+          interval: (value =~ PARSE_FIELDS_INTERVAL_REGEX ? $1.to_i : nil),
+          by_second: (value =~ PARSE_FIELDS_BY_SECOND_REGEX ? $1.split(',').map { |i| i.to_i } : nil),
+          by_minute: (value =~ PARSE_FIELDS_BY_MINUTE_REGEX ? $1.split(',').map { |i| i.to_i } : nil),
+          by_hour: (value =~ PARSE_FIELDS_BY_HOUR_REGEX ? $1.split(',').map { |i| i.to_i } : nil),
+          by_day: (value =~ PARSE_FIELDS_BY_DAY_REGEX ? $1.split(',') : nil),
+          by_month_day: (value =~ PARSE_FIELDS_BY_MONTH_DAY_REGEX ? $1.split(',') : nil),
+          by_year_day: (value =~ PARSE_FIELDS_BY_YEAR_DAY_REGEX ? $1.split(',') : nil),
+          by_week_number: (value =~ PARSE_FIELDS_BY_WEEK_NUMBER_REGEX ? $1.split(',') : nil),
+          by_month: (value =~ PARSE_FIELDS_BY_MONTH_REGEX ? $1.split(',').map { |i| i.to_i } : nil),
+          by_set_position: (value =~ PARSE_FIELDS_BY_SET_POSITON_REGEX ? $1.split(',') : nil),
+          week_start: (value =~ PARSE_FIELDS_BY_WEEK_START_REGEX ? $1.upcase : nil)
         }
       end
     end

--- a/lib/icalendar/values/recur.rb
+++ b/lib/icalendar/values/recur.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 module Icalendar

--- a/lib/icalendar/values/text.rb
+++ b/lib/icalendar/values/text.rb
@@ -9,12 +9,14 @@ module Icalendar
         super value, params
       end
 
+      VALUE_ICAL_CARRIAGE_RETURN_GSUB_REGEX = /\r?\n/.freeze
+
       def value_ical
         value.dup.tap do |v|
           v.gsub!('\\') { '\\\\' }
           v.gsub!(';', '\;')
           v.gsub!(',', '\,')
-          v.gsub!(/\r?\n/, '\n')
+          v.gsub!(VALUE_ICAL_CARRIAGE_RETURN_GSUB_REGEX, '\n')
         end
       end
     end

--- a/lib/icalendar/values/text.rb
+++ b/lib/icalendar/values/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
   module Values
     class Text < Value

--- a/lib/icalendar/values/time.rb
+++ b/lib/icalendar/values/time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 require_relative 'time_with_zone'
 

--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'icalendar/timezone_store'
 
 begin

--- a/lib/icalendar/values/uri.rb
+++ b/lib/icalendar/values/uri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 
 module Icalendar

--- a/lib/icalendar/values/utc_offset.rb
+++ b/lib/icalendar/values/utc_offset.rb
@@ -36,8 +36,11 @@ module Icalendar
         hours == 0 && minutes == 0 && seconds == 0
       end
 
+      PARSE_FIELDS_MD_REGEX = /\A(?<behind>[+-])(?<hours>\d{2})(?<minutes>\d{2})(?<seconds>\d{2})?\z/.freeze
+      PARSE_FIELDS_WHITESPACE_GSUB_REGEX = /\s+/.freeze
+
       def parse_fields(value)
-        md = /\A(?<behind>[+-])(?<hours>\d{2})(?<minutes>\d{2})(?<seconds>\d{2})?\z/.match value.gsub(/\s+/, '')
+        md = PARSE_FIELDS_MD_REGEX.match value.gsub(PARSE_FIELDS_WHITESPACE_GSUB_REGEX, '')
         {
           behind: (md[:behind] == '-'),
           hours: md[:hours].to_i,

--- a/lib/icalendar/values/utc_offset.rb
+++ b/lib/icalendar/values/utc_offset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 module Icalendar

--- a/lib/icalendar/version.rb
+++ b/lib/icalendar/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Icalendar
 
   VERSION = '2.8.0'


### PR DESCRIPTION
Moving Regexes to constants & freeze for performance allows the Ruby interpreter to prebuild the regexes and freeze them, dramatically improving the performance of parsing & serializing.

Also added `#frozen_string_literal: true` to library code for a similar performance hint

## Benchmarks

The following benchmarks were performed with a distressingly large (15MB) iCal file, over 100 iterations:

```
$ bundle exec ruby test.rb
                            user        system    total      real
UNMODIFIED:                 756.146293  15.460560 771.606853 (774.325547)

$ bundle exec ruby test.rb
                            user         system   total      real
FROZEN REGEXES:             351.734801   5.719803 357.454604 (359.078225)

$ bundle exec ruby test.rb
                            user         system   total      real
FROZEN STRINGS & REGEXES:   329.467007   6.071596 335.538603 (336.731739)
```