### PR TITLE
Add Ruby 3.2.2 to Ci pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           - 2.7.6
           - 3.0.4
           - 3.1.2
+          - 3.2.2
 
     steps:
     - uses: actions/checkout@v2

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -51,8 +51,8 @@ describe Icalendar::Event do
   context 'suggested single values' do
     before(:each) do
       subject.dtstart = DateTime.now
-      subject.append_rrule double('RRule').as_null_object
-      subject.append_rrule double('RRule').as_null_object
+      subject.append_rrule 'RRule'
+      subject.append_rrule 'RRule'
     end
 
     it 'is valid by default' do


### PR DESCRIPTION
Run CI against Ruby 3.2. 

Had to adjust a spec since under 3.2 a `double.as_null_object` when used with `=~` simply returns the double, rather than nil.
