### PR TITLE
Rescue unfound tzid

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,4 +1,6 @@
 === Unreleased
+ * Add changelog metadata to gemspec - Juri Hahn
+ * Attempt to rescue timezone info when given a nonstandard tzid with no VTIMEZONE
 
 === 2.9.0 2023-08-11
  * Always include the VALUE of Event URLs for improved compatibility - Sean Kelley

--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'icalendar/timezone_store'
-
 begin
   require 'active_support/time'
 

--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -42,7 +42,7 @@ module Icalendar
           elsif defined?(ActiveSupport::TimeZone) &&
               defined?(ActiveSupportTimeWithZoneAdapter) &&
               (tz = ActiveSupport::TimeZone[tzid.split.first])
-            params['tzid'] = tz.tzinfo.name
+            params['tzid'] = [tz.tzinfo.name]
             ActiveSupportTimeWithZoneAdapter.new(nil, tz, value)
           end
         end

--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -41,6 +41,11 @@ module Icalendar
             else
               ::Time.new value.year, value.month, value.day, value.hour, value.min, value.sec, offset
             end
+          elsif defined?(ActiveSupport::TimeZone) &&
+              defined?(ActiveSupportTimeWithZoneAdapter) &&
+              (tz = ActiveSupport::TimeZone[tzid.split.first])
+            params['tzid'] = tz.tzinfo.name
+            ActiveSupportTimeWithZoneAdapter.new(nil, tz, value)
           end
         end
         super((offset_value || value), params)

--- a/spec/values/date_time_spec.rb
+++ b/spec/values/date_time_spec.rb
@@ -27,6 +27,21 @@ describe Icalendar::Values::DateTime do
           expect(subject.value.utc.hour).to eq 23
         end
       end
+
+      context 'nonstandard format tzid local time' do
+        let(:value) { '20230901T230404' }
+        let(:params) { {'tzid' => 'Singapore Standard Time'} }
+
+        it 'parses the value as local time' do
+          expect(subject.value.hour).to eq 23
+          expect(subject.value.utc_offset).to eq 28800
+          expect(subject.value.utc.hour).to eq 15
+        end
+
+        it 'updates the tzid' do
+          expect(subject.ical_params['tzid']).to eq 'Asia/Singapore'
+        end
+      end
     end
 
   else

--- a/spec/values/date_time_spec.rb
+++ b/spec/values/date_time_spec.rb
@@ -39,7 +39,8 @@ describe Icalendar::Values::DateTime do
         end
 
         it 'updates the tzid' do
-          expect(subject.ical_params['tzid']).to eq 'Asia/Singapore'
+          # use an array because that's how output from the parser will end up
+          expect(subject.ical_params['tzid']).to eq ['Asia/Singapore']
         end
       end
     end


### PR DESCRIPTION
Attempt to deal nicely with sources that include a TZID that isn't found directly in the tzinfo gem and also don't specify the `VTIMEZONE` component.