### PR TITLE
Make TimeWithZone a class

### DIFF
--- a/lib/icalendar/values/time_with_zone.rb
+++ b/lib/icalendar/values/time_with_zone.rb
@@ -18,7 +18,7 @@ end
 
 module Icalendar
   module Values
-    module TimeWithZone
+    class TimeWithZone
       attr_reader :tz_utc
 
       def initialize(value, params = {})


### PR DESCRIPTION
Hi, it seems that `TimeWithZone` is accidentally a module.

Thanks for the gem, it's great!