### PR TITLE
Classify parse error to make it easily rescueable

### DIFF
--- a/lib/icalendar/parser.rb
+++ b/lib/icalendar/parser.rb
@@ -197,7 +197,7 @@ module Icalendar
         value = parts[:value]
       else
         parts = BAD_LINE_REGEX.match(input) unless strict?
-        parts or fail "Invalid iCalendar input line: #{input}"
+        parts or fail ParseError, "Invalid iCalendar input line: #{input}"
         # Non-strict and bad line so use a value of empty string
         value = ''
       end
@@ -226,6 +226,9 @@ module Icalendar
         params: params,
         value: value
       }
+    end
+
+    class ParseError < RuntimeError
     end
   end
 end


### PR DESCRIPTION
Hi, thanks a bunch for this gem! It's saved me a lot of time.

I have a need to provide a friendly error message to the user when they upload a file that isn't an .ics file. I wanted to rescue from the parse error, which was difficult because it was just a generic `RuntimeError`. This PR classifies it as a `Icalendar::Parser::ParseError`, which is a suclass of `RuntimeError`, so it should be backwards compatible.