### PR TITLE
Consistent value equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+ - Override Icalendar::Value.== so that value objects can be compared to each other.
+
+
 ## 2.10.2 - 2024-07-21
  - Raise Icalendar::Parser::ParseError on bad .ics file input instead of RuntimeError - Micah Geisel
  - Remove Ruby 3.0 from the test matrix - still should work for now with ice_cube < 0.17.0

--- a/lib/icalendar/value.rb
+++ b/lib/icalendar/value.rb
@@ -45,6 +45,14 @@ module Icalendar
       self.class.value_type
     end
 
+    def ==(other)
+      if other.is_a?(Icalendar::Value)
+        super(other.value) && ical_params == other.ical_params
+      else
+        super
+      end
+    end
+
     private
 
     def needs_value_type?(default_type)

--- a/lib/icalendar/version.rb
+++ b/lib/icalendar/version.rb
@@ -2,6 +2,6 @@
 
 module Icalendar
 
-  VERSION = '2.10.2'
+  VERSION = '2.10.3'
 
 end

--- a/spec/values/date_spec.rb
+++ b/spec/values/date_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Icalendar::Values::Date do
+
+  subject { described_class.new value, params }
+  let(:value) { '20140209' }
+  let(:params) { {} }
+
+  describe "#==" do
+    let(:other) { described_class.new value }
+
+    it "is equivalent to another Icalendar::Values::Date" do
+      expect(subject).to eq other
+    end
+
+    context "differing params" do
+      let(:params) { {"x-custom-param": "param-value"} }
+
+      it "is no longer equivalent" do
+        expect(subject).not_to eq other
+      end
+    end
+  end
+end


### PR DESCRIPTION
Overrides `:==` in `Icalendar::Value` so that all subclasses can check for equality in a hopefully unsurprising way.

It both objects are `Icalendar::Value` objects, then they'll be equal if the underlying values are equal and their parameters are equal.

Closes #297 