### PR TITLE
Add ostruct to gemspec as a dependency

### DIFF
--- a/icalendar.gemspec
+++ b/icalendar.gemspec
@@ -32,6 +32,7 @@ ActiveSupport is required for TimeWithZone support, but not required for general
   s.required_ruby_version = '>= 2.4.0'
 
   s.add_dependency 'ice_cube', '~> 0.16'
+  s.add_dependency 'ostruct'
 
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
Fixes the warning with Ruby 3.3.5:


_.../vendor/bundle/ruby/3.3.0/gems/icalendar-2.10.2/lib/icalendar/value.rb:83: warning: .../.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0._
