### PR TITLE
Correctly load active support within time_with_zone

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.1.6
-          - 3.2.4
-          - 3.3.4
+          - 3.1
+          - 3.2
+          - 3.3
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
  - Override Icalendar::Value.== so that value objects can be compared to each other.
+ - Correctly load activesupport before activesupport/time
 
 
 ## 2.10.2 - 2024-07-21

--- a/lib/icalendar/values/helpers/time_with_zone.rb
+++ b/lib/icalendar/values/helpers/time_with_zone.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 
 begin
+  require 'active_support'
   require 'active_support/time'
 
   if defined?(ActiveSupport::TimeWithZone)
     require_relative 'active_support_time_with_zone_adapter'
   end
-rescue NameError
-  # ActiveSupport v7+ needs the base require to be run first before loading
-  # specific parts of it.
-  # https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support
-  require 'active_support'
-  retry
 rescue LoadError
   # tis ok, just a bit less fancy
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,12 @@ end
 require 'timecop'
 require 'icalendar'
 
+if defined?(ActiveSupport)
+  # this has been default behavior for new Rails apps for a long time, and the
+  # only option once ActiveSupport goes to 8.x
+  ActiveSupport.to_time_preserves_timezone = true if ActiveSupport.respond_to?(:to_time_preserves_timezone=)
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
Prevents load errors on ActiveSupport >= 7.2