### PR TITLE
Fix error and deprecation warning on Ruby 3.4+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           - 3.1
           - 3.2
           - 3.3
+          - 3.4
 
     steps:
     - uses: actions/checkout@v4

--- a/icalendar.gemspec
+++ b/icalendar.gemspec
@@ -33,6 +33,7 @@ ActiveSupport is required for TimeWithZone support, but not required for general
 
   s.add_dependency 'base64'
   s.add_dependency 'ice_cube', '~> 0.16'
+  s.add_dependency 'logger'
   s.add_dependency 'ostruct'
 
   s.add_development_dependency 'rake', '~> 13.0'

--- a/icalendar.gemspec
+++ b/icalendar.gemspec
@@ -31,6 +31,7 @@ ActiveSupport is required for TimeWithZone support, but not required for general
 
   s.required_ruby_version = '>= 2.4.0'
 
+  s.add_dependency 'base64'
   s.add_dependency 'ice_cube', '~> 0.16'
   s.add_dependency 'ostruct'
 


### PR DESCRIPTION
Fixed error and warning when require icalendar on Ruby 3.4+

# Example
```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "icalendar", "2.10.3"
end

require "icalendar"
```

```
$ ruby -v
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]

$ ruby icalendar_poc.rb 
/Users/sue445/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/icalendar-2.10.3/lib/icalendar/logger.rb:4: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
/Users/sue445/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/icalendar-2.10.3/lib/icalendar/values/binary.rb:3: warning: base64 was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
/Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- base64 (LoadError)
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/icalendar-2.10.3/lib/icalendar/values/binary.rb:3:in '<top (required)>'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/icalendar-2.10.3/lib/icalendar/value.rb:87:in 'Kernel#require_relative'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/icalendar-2.10.3/lib/icalendar/value.rb:87:in '<top (required)>'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/icalendar-2.10.3/lib/icalendar.rb:29:in '<top (required)>'
        from <internal:/Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
        from <internal:/Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel.replace_require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/runtime.rb:65:in 'block (2 levels) in Bundler::Runtime#require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/runtime.rb:60:in 'Array#each'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/runtime.rb:60:in 'block in Bundler::Runtime#require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/runtime.rb:52:in 'Array#each'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/runtime.rb:52:in 'Bundler::Runtime#require'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/inline.rb:89:in 'block in Object#gemfile'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/settings.rb:159:in 'Bundler::Settings#temporary'
        from /Users/sue445/.rbenv/versions/3.4.1/lib/ruby/3.4.0/bundler/inline.rb:58:in 'Object#gemfile'
        from vendor/icalendar_poc.rb:3:in '<main>'
```