### PR TITLE
Refactor offset_value method into classes

### DIFF
--- a/lib/icalendar/offset.rb
+++ b/lib/icalendar/offset.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Icalendar
+  class Offset
+    def self.build(value, params, timezone_store)
+      return nil if params.nil? || params['tzid'].nil?
+
+      tzid = Array(params['tzid']).first
+
+      [
+        Icalendar::Offset::ActiveSupportExact,
+        Icalendar::Offset::TimeZoneStore,
+        Icalendar::Offset::ActiveSupportPartial,
+        Icalendar::Offset::Null
+      ].collect { |klass| klass.new(tzid, value, timezone_store) }.detect(&:valid?)
+    end
+
+    def initialize(tzid, value, timezone_store)
+      @tzid = tzid
+      @value = value
+      @timezone_store = timezone_store
+    end
+
+    def normalized_tzid
+      Array(tzid)
+    end
+
+    private
+
+    attr_reader :tzid, :value, :timezone_store
+
+    def support_classes_defined?
+      defined?(ActiveSupport::TimeZone) &&
+        defined?(Icalendar::Values::Helpers::ActiveSupportTimeWithZoneAdapter)
+    end
+  end
+end
+
+require_relative "offset/active_support_exact"
+require_relative "offset/active_support_partial"
+require_relative "offset/null"
+require_relative "offset/time_zone_store"

--- a/lib/icalendar/offset.rb
+++ b/lib/icalendar/offset.rb
@@ -12,7 +12,7 @@ module Icalendar
         Icalendar::Offset::TimeZoneStore,
         Icalendar::Offset::ActiveSupportPartial,
         Icalendar::Offset::Null
-      ].collect { |klass| klass.new(tzid, value, timezone_store) }.detect(&:valid?)
+      ].lazy.map { |klass| klass.new(tzid, value, timezone_store) }.detect(&:valid?)
     end
 
     def initialize(tzid, value, timezone_store)

--- a/lib/icalendar/offset/active_support_exact.rb
+++ b/lib/icalendar/offset/active_support_exact.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Icalendar
+  class Offset
+    class ActiveSupportExact < Icalendar::Offset
+      def valid?
+        support_classes_defined? && tz
+      end
+
+      def normalized_value
+        Icalendar.logger.debug("Plan a - parsing #{value}/#{tzid} as ActiveSupport::TimeWithZone")
+        # plan a - use ActiveSupport::TimeWithZone
+        Icalendar::Values::Helpers::ActiveSupportTimeWithZoneAdapter.new(nil, tz, value)
+      end
+
+      private
+
+      def tz
+        @tz ||= ActiveSupport::TimeZone[tzid]
+      end
+    end
+  end
+end

--- a/lib/icalendar/offset/active_support_partial.rb
+++ b/lib/icalendar/offset/active_support_partial.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Icalendar
+  class Offset
+    class ActiveSupportPartial < Offset
+      def valid?
+        support_classes_defined? && tz
+      end
+
+      def normalized_value
+        # plan c - try to find an ActiveSupport::TimeWithZone based on the first word of the tzid
+        Icalendar.logger.debug("Plan c - parsing #{value}/#{tz.tzinfo.name} as ActiveSupport::TimeWithZone")
+        Icalendar::Values::Helpers::ActiveSupportTimeWithZoneAdapter.new(nil, tz, value)
+      end
+
+      def normalized_tzid
+        [tz.tzinfo.name]
+      end
+
+      private
+
+      def tz
+        @tz ||= ActiveSupport::TimeZone[tzid.split.first]
+      end
+    end
+  end
+end

--- a/lib/icalendar/offset/null.rb
+++ b/lib/icalendar/offset/null.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Icalendar
+  class Offset
+    class Null < Offset
+      def valid?
+        true
+      end
+
+      def normalized_value
+        # plan d - just ignore the tzid
+        Icalendar.logger.info("Ignoring timezone #{tzid} for time #{value}")
+        nil
+      end
+    end
+  end
+end

--- a/lib/icalendar/offset/time_zone_store.rb
+++ b/lib/icalendar/offset/time_zone_store.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Icalendar
+  class Offset
+    class TimeZoneStore < Offset
+      def valid?
+        timezone_store && tz_info
+      end
+
+      def normalized_value
+        # plan b - use definition from provided `VTIMEZONE`
+        offset = tz_info.offset_for_local(value).to_s
+
+        Icalendar.logger.debug("Plan b - parsing #{value} with offset: #{offset}")
+        if value.respond_to?(:change)
+          value.change offset: offset
+        else
+          ::Time.new value.year, value.month, value.day, value.hour, value.min, value.sec, offset
+        end
+      end
+
+      private
+
+      def tz_info
+        @tz_info ||= timezone_store.retrieve(tzid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors the `offset_value` method in `Icalendar::Values::Helpers::TimeWithZone` out into several classes, one for each approach of parsing the offset and time value.

I also considered a single class with all of the conditions in it (indeed, I have that in a separate branch locally), but I found it still a bit overwhelming. The approach I've chosen here is maybe more verbose, but I personally find it to be clearer.

There's no behaviour changes - this is just a refactor for (my) clarity. Though, it is prompted by some monkey-patching in an app of mine that has to deal with Microsoft's flawed generation of ICS files.