### PR TITLE
Rails 7 - DEPRECATION WARNING: Using a :default format for DateTime#to_s is deprecated. #315

### DIFF
--- a/lib/icalendar/offset/active_support_exact.rb
+++ b/lib/icalendar/offset/active_support_exact.rb
@@ -8,7 +8,7 @@ module Icalendar
       end
 
       def normalized_value
-        Icalendar.logger.debug("Plan a - parsing #{value}/#{tzid} as ActiveSupport::TimeWithZone")
+        Icalendar.logger.debug("Plan a - parsing #{value.to_fs(:default)}/#{tzid} as ActiveSupport::TimeWithZone")
         # plan a - use ActiveSupport::TimeWithZone
         Icalendar::Values::Helpers::ActiveSupportTimeWithZoneAdapter.new(nil, tz, value)
       end

--- a/lib/icalendar/offset/active_support_partial.rb
+++ b/lib/icalendar/offset/active_support_partial.rb
@@ -9,7 +9,7 @@ module Icalendar
 
       def normalized_value
         # plan c - try to find an ActiveSupport::TimeWithZone based on the first word of the tzid
-        Icalendar.logger.debug("Plan c - parsing #{value}/#{tz.tzinfo.name} as ActiveSupport::TimeWithZone")
+        Icalendar.logger.debug("Plan c - parsing #{value.to_fs(:default)}/#{tz.tzinfo.name} as ActiveSupport::TimeWithZone")
         Icalendar::Values::Helpers::ActiveSupportTimeWithZoneAdapter.new(nil, tz, value)
       end
 

--- a/lib/icalendar/offset/time_zone_store.rb
+++ b/lib/icalendar/offset/time_zone_store.rb
@@ -11,7 +11,7 @@ module Icalendar
         # plan b - use definition from provided `VTIMEZONE`
         offset = tz_info.offset_for_local(value).to_s
 
-        Icalendar.logger.debug("Plan b - parsing #{value} with offset: #{offset}")
+        Icalendar.logger.debug("Plan b - parsing #{value.to_fs(:default)} with offset: #{offset}")
         if value.respond_to?(:change)
           value.change offset: offset
         else


### PR DESCRIPTION
1. Those who are using the icalendar gem facing issue to pass test cases bz of icalendar debug the values of date/time
2. In Test env rails suggest to use to_fs for date/time values
